### PR TITLE
Add support to create a new document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 /tmp/
 /.rubocop-https---**
 /Gemfile.lock
+/templates/*
+!/templates/base
 
 # rspec failure tracking
 .rspec_status

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_install:
   - gem install bundler -v 2.0.1
   - bundle update
   - unset _JAVA_OPTIONS
+  - mkdir ./tmp
+
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/exe/metanorma-new
+++ b/exe/metanorma-new
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+
+# resolve bin path, ignoring symlinks
+require "pathname"
+bin_file = Pathname.new(__FILE__).realpath
+
+# add self to libpath
+$:.unshift File.expand_path("../../lib", bin_file)
+
+# Fixes https://github.com/rubygems/rubygems/issues/1420
+require "rubygems/specification"
+
+class Gem::Specification
+  def this; self; end
+end
+
+# start up the CLI
+require "bundler/setup"
+require "metanorma/cli"
+
+Metanorma::Cli.start(ARGV)

--- a/lib/metanorma/cli.rb
+++ b/lib/metanorma/cli.rb
@@ -1,5 +1,6 @@
-require "metanorma/cli/version"
 require "metanorma"
+require "metanorma/cli/version"
+require "metanorma/cli/command"
 
 module Metanorma
   module Cli
@@ -40,5 +41,12 @@ module Metanorma
       load_flavors(flavor_names)
     end
 
+    def self.start(arguments)
+      Metanorma::Cli::Command.start(arguments)
+    end
+
+    def self.root
+      File.dirname(__dir__)
+    end
   end
 end

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -1,0 +1,17 @@
+require "thor"
+require "metanorma/cli/generator"
+
+module Metanorma
+  module Cli
+    class Command < Thor
+      desc "new NAME", "Create new Metanorma document"
+      option :type, aliases: "-t", required: true, desc: "Document type"
+      option :doctype, aliases: "-d", required: true, desc: "Metanorma doctype"
+      option :overwrite, aliases: "-r", desc: "Overwrite existing document"
+
+      def new(document_name)
+        Metanorma::Cli::Generator.run(document_name, options)
+      end
+    end
+  end
+end

--- a/lib/metanorma/cli/generator.rb
+++ b/lib/metanorma/cli/generator.rb
@@ -1,0 +1,98 @@
+require "pathname"
+require "fileutils"
+require "metanorma/cli/ui"
+
+module Metanorma
+  module Cli
+    class Generator
+      def initialize(document_name, options)
+        @document_name = document_name
+        @type = options.fetch(:type, nil)
+        @target = Pathname.pwd.join(document_name)
+        @overwrite = options.fetch(:overwrite, false)
+        @doctype = options.fetch(:doctype, "standard")
+      end
+
+      def run
+        target.rmtree if target.exist? && deletable?
+        templates = base_templates.merge(type_specific_templates)
+        templates.each { |source, dest| create_file(source, dest) }
+      end
+
+      def self.run(document_name, options)
+        new(document_name, options).run
+      end
+
+      private
+
+      attr_reader :type, :doctype, :target, :document_name
+
+      def deletable?
+        @overwrite == true || ask_to_confirm === "yes"
+      end
+
+      def templates_sources
+        @templates_sources ||= {
+          csd: "https://github.com/metanorma/mn-templates-csd",
+        }
+      end
+
+      def base_templates
+        templates = [template_dir, "base"].join("/")
+        build_template_hash(dir_files(templates), templates)
+      end
+
+      def type_specific_templates
+        type_template_path.exist? || download_tempales
+        type_template = [template_dir, type].join("/")
+        build_template_hash(dir_files(type_template, doctype), type_template)
+      end
+
+      def build_template_hash(elements, source_root)
+        Hash.new.tap do |hash|
+          elements.each do |element|
+            hash[element] = element.gsub("#{source_root}/", "")
+          end
+        end
+      end
+
+      def download_tempales
+        git = UI.run("which git")
+        tempalte_source = templates_sources[type.to_sym]
+
+        if !git.nil? && tempalte_source
+          UI.say("Downloading #{type} tempaltes ...")
+          UI.run("git clone #{tempalte_source} #{template_dir}/#{type}")
+        end
+      end
+
+      def create_file(source, destination)
+        target_path = [target, destination].join("/")
+        target_path = Pathname.new(target_path)
+        target_path.dirname.mkdir unless target_path.dirname.exist?
+
+        FileUtils.copy_entry(source, target_path)
+      end
+
+      def dir_files(*arguments)
+        paths = [*arguments, "**", "**"].join("/")
+        Pathname.glob(paths).reject(&:directory?).map(&:to_s)
+      end
+
+      def template_dir
+        @template_dir ||= [File.dirname(Cli.root), "templates"].join("/")
+      end
+
+      def type_template_path
+        @type_template_path ||= Pathname.new([template_dir, type].join("/"))
+      end
+
+      def ask_to_confirm
+        UI.ask(
+          "You've an existing document with the same name\n" \
+          "Still want to continue, and overwrite the existing one? (yes/no):",
+        ).downcase
+      end
+    end
+  end
+end

--- a/lib/metanorma/cli/generator.rb
+++ b/lib/metanorma/cli/generator.rb
@@ -15,6 +15,7 @@ module Metanorma
 
       def run
         target.rmtree if target.exist? && deletable?
+
         templates = base_templates.merge(type_specific_templates)
         templates.each { |source, dest| create_file(source, dest) }
       end
@@ -69,8 +70,12 @@ module Metanorma
       def create_file(source, destination)
         target_path = [target, destination].join("/")
         target_path = Pathname.new(target_path)
-        target_path.dirname.mkdir unless target_path.dirname.exist?
 
+        unless target_path.dirname.exist?
+          FileUtils.mkdir_p(target_path.dirname)
+        end
+
+        UI.say("Creating #{document_name}/#{destination}")
         FileUtils.copy_entry(source, target_path)
       end
 

--- a/lib/metanorma/cli/ui.rb
+++ b/lib/metanorma/cli/ui.rb
@@ -1,0 +1,20 @@
+require "thor"
+
+module Metanorma
+  module Cli
+    class UI < Thor
+      def self.ask(message)
+        new.ask(message)
+      end
+
+      def self.say(message)
+        new.say(message)
+      end
+
+      def self.run(command)
+        require "open3"
+        Open3.capture3(command)
+      end
+    end
+  end
+end

--- a/metanorma-cli.gemspec
+++ b/metanorma-cli.gemspec
@@ -30,10 +30,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug", "~> 10.0"
   spec.add_development_dependency "rspec-command", "~> 1.0.3"
   spec.add_development_dependency "equivalent-xml", "~> 0.6"
-  spec.add_development_dependency 'rspec-core', "~> 3.4"
+  spec.add_development_dependency "rspec-core", "~> 3.4"
 
-
-  spec.add_runtime_dependency 'metanorma-iso', "~> 1.1.0"
+  spec.add_runtime_dependency "thor", "~> 0.20.3"
+  spec.add_runtime_dependency "metanorma-iso", "~> 1.1.0"
   spec.add_runtime_dependency 'metanorma-ietf', "~> 1.0.1"
   spec.add_runtime_dependency 'metanorma-gb', "~> 1.1.0"
   spec.add_runtime_dependency 'metanorma-csd', "~> 1.1.0"

--- a/spec/acceptance/new_spec.rb
+++ b/spec/acceptance/new_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe "Metanorma" do
+  describe "new document" do
+    it "creates a new metanorma document" do
+      allow(Metanorma::Cli::Generator).to receive(:run)
+
+      command = %w(new -t iso -d standard ./tmp/my-iso-doc)
+      capture_stdout { Metanorma::Cli.start(command) }
+
+      expect(Metanorma::Cli::Generator).to have_received(:run)
+    end
+  end
+end

--- a/spec/metanorma/cli/generator_spec.rb
+++ b/spec/metanorma/cli/generator_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe Metanorma::Cli::Generator do
       it "downloads and generate new document" do
         document = "./tmp/my-document"
 
-        Metanorma::Cli::Generator.new(
-          document, type: "csd", doctype: "standard", overwrite: true
-        ).run
+        capture_stdout {
+          Metanorma::Cli::Generator.run(
+            document, type: "csd", doctype: "standard", overwrite: true
+          )
+        }
 
         expect(file_exits?(document, "Gemfile")).to be_truthy
         expect(file_exits?(document, "Makefile")).to be_truthy

--- a/spec/metanorma/cli/generator_spec.rb
+++ b/spec/metanorma/cli/generator_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+RSpec.describe Metanorma::Cli::Generator do
+  describe ".run" do
+    context "without existing tempaltes" do
+      it "downloads and generate new document" do
+        document = "./tmp/my-document"
+
+        Metanorma::Cli::Generator.new(
+          document, type: "csd", doctype: "standard", overwrite: true
+        ).run
+
+        expect(file_exits?(document, "Gemfile")).to be_truthy
+        expect(file_exits?(document, "Makefile")).to be_truthy
+        expect(file_exits?(document, "standard/README.adoc")).to be_truthy
+
+        expect(
+          file_exits?(document, "standard/sections/01-scope.adoc"),
+        ).to be_truthy
+      end
+    end
+  end
+
+  def file_exits?(root, filename)
+    File.exist?([root, filename].join("/"))
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,15 @@
 require "bundler/setup"
 require "equivalent-xml"
 require "rspec-command"
+require "metanorma/cli"
 require "fileutils"
+
+Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+  config.include Metanorma::ConsoleHelper
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/spec/support/console_helper.rb
+++ b/spec/support/console_helper.rb
@@ -1,0 +1,29 @@
+module Metanorma
+  module ConsoleHelper
+    def capture_stdout(&_block)
+      original_stdout = $stdout
+      $stdout = fake = StringIO.new
+
+      begin
+        yield
+      ensure
+        $stdout = original_stdout
+      end
+
+      fake.string
+    end
+
+    def capture_stderr(&_block)
+      original_stderr = $stderr
+      $stderr = fake = StringIO.new
+
+      begin
+        yield
+      ensure
+        $stderr = original_stderr
+      end
+
+      fake.string
+    end
+  end
+end

--- a/templates/base/Gemfile
+++ b/templates/base/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "metanorma-cli"
+gem "relaton-cli"

--- a/templates/base/Makefile
+++ b/templates/base/Makefile
@@ -1,0 +1,126 @@
+#!make
+SHELL := /bin/bash
+
+FORMAT_MARKER := mn-output-
+FORMATS := $(shell grep "$(FORMAT_MARKER)" *.adoc | cut -f 2 -d ' ' | tr ',' '\n' | sort | uniq | tr '\n' ' ')
+
+SRC  := $(filter-out README.adoc, $(wildcard *.adoc))
+XML  := $(patsubst %.adoc,%.xml,$(SRC))
+HTML := $(patsubst %.adoc,%.html,$(SRC))
+DOC  := $(patsubst %.adoc,%.doc,$(SRC))
+PDF  := $(patsubst %.adoc,%.pdf,$(SRC))
+WSD  := $(wildcard models/*.wsd)
+XMI	 := $(patsubst models/%,xmi/%,$(patsubst %.wsd,%.xmi,$(WSD)))
+PNG	 := $(patsubst models/%,images/%,$(patsubst %.wsd,%.png,$(WSD)))
+
+COMPILE_CMD_LOCAL := bundle exec metanorma $$FILENAME
+COMPILE_CMD_DOCKER := docker run -v "$$(pwd)":/metanorma/ ribose/metanorma "metanorma $$FILENAME"
+
+ifdef METANORMA_DOCKER
+  COMPILE_CMD := echo "Compiling via docker..."; $(COMPILE_CMD_DOCKER)
+else
+  COMPILE_CMD := echo "Compiling locally..."; $(COMPILE_CMD_LOCAL)
+endif
+
+_OUT_FILES := $(foreach FORMAT,$(FORMATS),$(shell echo $(FORMAT) | tr '[:lower:]' '[:upper:]'))
+OUT_FILES  := $(foreach F,$(_OUT_FILES),$($F))
+
+all: images $(OUT_FILES)
+
+%.xml %.html %.doc %.pdf:	%.adoc | bundle
+	FILENAME=$^; \
+	${COMPILE_CMD}
+
+images: $(PNG)
+
+images/%.png: models/%.wsd
+	plantuml -tpng -o ../images/ $<
+
+xmi: $(XMI)
+
+xmi/%.xmi: models/%.wsd
+	plantuml -xmi:star -o ../xmi/ $<
+
+define FORMAT_TASKS
+OUT_FILES-$(FORMAT) := $($(shell echo $(FORMAT) | tr '[:lower:]' '[:upper:]'))
+
+open-$(FORMAT):
+	open $$(OUT_FILES-$(FORMAT))
+
+clean-$(FORMAT):
+	rm -f $$(OUT_FILES-$(FORMAT))
+
+$(FORMAT): clean-$(FORMAT) $$(OUT_FILES-$(FORMAT))
+
+.PHONY: clean-$(FORMAT)
+
+endef
+
+$(foreach FORMAT,$(FORMATS),$(eval $(FORMAT_TASKS)))
+
+open: open-html
+
+clean:
+	rm -f $(OUT_FILES)
+
+bundle:
+	if [ "x" == "${METANORMA_DOCKER}x" ]; then bundle; fi
+
+.PHONY: bundle all open clean
+
+#
+# Watch-related jobs
+#
+
+.PHONY: watch serve watch-serve
+
+NODE_BINS          := onchange live-serve run-p
+NODE_BIN_DIR       := node_modules/.bin
+NODE_PACKAGE_PATHS := $(foreach PACKAGE_NAME,$(NODE_BINS),$(NODE_BIN_DIR)/$(PACKAGE_NAME))
+
+$(NODE_PACKAGE_PATHS): package.json
+	npm i
+
+watch: $(NODE_BIN_DIR)/onchange
+	make all
+	$< $(ALL_SRC) -- make all
+
+define WATCH_TASKS
+watch-$(FORMAT): $(NODE_BIN_DIR)/onchange
+	make $(FORMAT)
+	$$< $$(SRC_$(FORMAT)) -- make $(FORMAT)
+
+.PHONY: watch-$(FORMAT)
+endef
+
+$(foreach FORMAT,$(FORMATS),$(eval $(WATCH_TASKS)))
+
+serve: $(NODE_BIN_DIR)/live-server revealjs-css reveal.js images
+	export PORT=$${PORT:-8123} ; \
+	port=$${PORT} ; \
+	for html in $(HTML); do \
+		$< --entry-file=$$html --port=$${port} --ignore="*.html,*.xml,Makefile,Gemfile.*,package.*.json" --wait=1000 & \
+		port=$$(( port++ )) ;\
+	done
+
+watch-serve: $(NODE_BIN_DIR)/run-p
+	$< watch serve
+
+#
+# Deploy jobs
+#
+
+publish:
+	mkdir -p published  && \
+	cp -a $(basename $(SRC)).* published/ && \
+	cp $(firstword $(HTML)) published/index.html; \
+	if [ -d "images" ]; then cp -a images published; fi
+
+deploy_key:
+	openssl aes-256-cbc -K $(encrypted_$(ENCRYPTION_LABEL)_key) \
+		-iv $(encrypted_$(ENCRYPTION_LABEL)_iv) -in $@.enc -out $@ -d && \
+	chmod 600 $@
+
+deploy: deploy_key
+	export COMMIT_AUTHOR_EMAIL=$(COMMIT_AUTHOR_EMAIL); \
+	./deploy.sh

--- a/templates/base/Makefile.win
+++ b/templates/base/Makefile.win
@@ -1,0 +1,63 @@
+#!make
+
+include metanorma.env
+export $(shell sed 's/=.*//' metanorma.env)
+
+FORMATS := $(METANORMA_FORMATS)
+comma := ,
+empty :=
+space := $(empty) $(empty)
+
+SRC  := $(filter-out README.adoc, $(wildcard *.adoc))
+XML  := $(patsubst %.adoc,%.xml,$(SRC))
+HTML := $(patsubst %.adoc,%.html,$(SRC))
+DOC  := $(patsubst %.adoc,%.doc,$(SRC))
+PDF  := $(patsubst %.adoc,%.pdf,$(SRC))
+RXL  := $(patsubst %.adoc,%.rxl,$(SRC))
+
+HOST_SHARE_DIR=$(USERPROFILE)\$(shell for %%I in (.) do echo %%~nxI)
+COMPILE_CMD_LOCAL := bundle exec metanorma -R $(RXL) $(SRC)
+COMPILE_CMD_DOCKER := C:/ProgramData/chocolatey/bin/docker run --rm -it -v $(CURDIR):/metanorma/ ribose/metanorma "metanorma -R $(RXL) $(SRC)"
+
+ifdef METANORMA_DOCKER
+  COMPILE_CMD := echo "Compiling via docker..." & $(COMPILE_CMD_DOCKER)
+else
+  COMPILE_CMD := echo "Compiling locally..." & $(COMPILE_CMD_LOCAL)
+endif
+
+_OUT_FILES := $(foreach FORMAT,$(FORMATS),$(shell echo $(FORMAT) | tr '[:lower:]' '[:upper:]'))
+OUT_FILES  := $(foreach F,$(_OUT_FILES),$($F))
+
+all: $(OUT_FILES)
+
+%.xml %.html %.doc %.pdf:	%.adoc | bundle
+	${COMPILE_CMD}
+
+define FORMAT_TASKS
+OUT_FILES-$(FORMAT) := $($(shell echo $(FORMAT) | tr '[:lower:]' '[:upper:]'))
+
+open-$(FORMAT):
+	$$(OUT_FILES-$(FORMAT))
+
+clean-$(FORMAT):
+	rm $$(OUT_FILES-$(FORMAT))
+
+$(FORMAT): clean-$(FORMAT) $$(OUT_FILES-$(FORMAT))
+
+.PHONY: clean-$(FORMAT)
+
+endef
+
+$(foreach FORMAT,$(FORMATS),$(eval $(FORMAT_TASKS)))
+
+# open: $(foreach FORMAT,$(FORMATS),open-$(FORMAT))
+
+open: open-html
+
+clean:
+	rm -rf $(OUT_FILES)
+
+bundle:
+	IF "" == "${METANORMA_DOCKER}" bundle
+
+.PHONY: bundle all open clean

--- a/templates/base/appveyor.yml
+++ b/templates/base/appveyor.yml
@@ -1,0 +1,29 @@
+version: '{build}'
+
+environment:
+  matrix:
+    - RUBY_VERSION: 25
+    - RUBY_VERSION: 24
+    - RUBY_VERSION: _trunk
+
+matrix:
+  allow_failures:
+    - RUBY_VERSION: _trunk
+
+install:
+  - ps: . { iwr -useb https://raw.githubusercontent.com/metanorma/metanorma-build-scripts/master/appveyor.ps1 } | iex
+  - refreshenv
+
+build_script:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle update
+  - bundle install
+
+before_test:
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - plantuml -testdot
+  - make -f Makefile.win clean all publish SHELL=cmd

--- a/templates/base/deploy.sh
+++ b/templates/base/deploy.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# TODO: replace this script when https://github.com/travis-ci/dpl/issues/694 is fixed
+# Taken from https://raw.githubusercontent.com/w3c/permissions/master/deploy.sh
+set -e # Exit with nonzero exit code if anything fails
+
+errx() {
+  readonly __progname=$(basename ${BASH_SOURCE})
+  echo -e "[${__progname}] $@" >&2
+  exit 1
+}
+
+SOURCE_BRANCH="master"
+TARGET_BRANCH="gh-pages"
+KEY_NAME=$(pwd)/deploy_key
+
+main() {
+
+  # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
+  if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
+    echo "Not a Travis PR or not matching branch ($SOURCE_BRANCH); skipping deploy."
+    exit 0
+  fi
+
+  [ -z "$COMMIT_AUTHOR_EMAIL" ] && \
+    errx "No COMMIT_AUTHOR_EMAIL provided; it must be set."
+
+  if [ ! -f ${KEY_NAME} ]; then
+    errx "No ${KEY_NAME} file detected; is ${KEY_NAME}.enc decrypted?"
+  fi
+
+  # Save some useful information
+  REPO=`git config remote.origin.url`
+  SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
+  SHA=`git rev-parse --verify HEAD`
+  DEST_DIR=out
+
+  # Clone the existing $TARGET_BRANCH for this repo into $DEST_DIR/
+  # Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deploy)
+  #  git clone $REPO $DEST_DIR
+  git clone $REPO $DEST_DIR || errx "Unable to clone Git."
+  pushd $DEST_DIR
+  git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH || errx "Unable to checkout git."
+  popd
+
+  # Clean out existing contents in $TARGET_BRANCH clone
+  rm -rf $DEST_DIR/* || exit 0
+
+  # Adding contents within published/ to $DEST_DIR.
+  cp -a published/* $DEST_DIR/ || exit 0
+
+  # Now let's go have some fun with the cloned repo
+  pushd $DEST_DIR
+  git config user.name "Travis CI"
+  git config user.email "$COMMIT_AUTHOR_EMAIL"
+
+  # If there are no changes to the compiled out (e.g. this is a README update) then just bail.
+  if [[ -z $(git status -s) ]]; then
+    echo "No changes to the output on this push; exiting."
+    exit 0
+  fi
+
+  git status
+
+  # Commit the "changes", i.e. the new version.
+  # The delta will show diffs between new and old versions.
+  git add .
+  git commit -m "Deploy to GitHub Pages: ${SHA}"
+
+  eval `ssh-agent -s`
+  ssh-add ${KEY_NAME}
+
+  # Now that we're all set up, we can push.
+  git push $SSH_REPO $TARGET_BRANCH || errx "Unable to push to git."
+}
+
+main "$@"
+
+exit 0


### PR DESCRIPTION
This commit adds a very simple and basic interface to create a new metanorma document, it currently supports csd document but very soon we will add all of the other supported document.

The adds a temporary new executable `exe/metanorma-new` and this will allow us to create a new document, and the way we can do it now is to use the following command.

```sh
exe/metanorma-new new -t csd -d standard my-csd-document
```

Fair warning, this is still in a very early stage to support our use case, but we will soon clean up this and make it as friendly as possible.