### PR TITLE
Add support to use git template for document

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
   - gem install bundler -v 2.0.1
   - bundle update
   - unset _JAVA_OPTIONS
-  - mkdir ./tmp
 
 matrix:
   allow_failures:

--- a/lib/metanorma/cli.rb
+++ b/lib/metanorma/cli.rb
@@ -44,7 +44,7 @@ module Metanorma
     # In the Metanorma CLI, we've included some custom behavior,
     # like exposing the compiation directly from the root command.
     #
-    # So, for this use case we firs check if the user is actually
+    # So, for this use case we first check if the user is actually
     # trying to compile a document or not, and based on that we'll
     # compile the document or show the help documentation.
     #
@@ -60,17 +60,14 @@ module Metanorma
       File.dirname(__dir__)
     end
 
+    def self.templates_path
+      root_path.join("templates")
+    end
+
     def self.root_path
       Pathname.new(Cli.root).join("..")
     end
 
-    # Impoartant Note
-    #
-    # This is a workaround to invoke the `compile` as a default
-    # command for the cli, so whenever you are adding a new command
-    # please make sure you add it to this list as well, only then it
-    # will behave as expected.
-    #
     def self.find_command(arguments)
       commands = Metanorma::Cli::Command.all_commands.keys
       commands.select { |cmd| arguments.include?(cmd) == true }

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -35,6 +35,9 @@ module Metanorma
         elsif options[:version]
           invoke(:version, [], type: options[:type] || :iso, format: options[:format])
 
+        elsif options.keys.size >= 2
+          UI.say("Need to specify a file to process")
+
         else
           invoke :help
         end

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -1,6 +1,7 @@
 require "thor"
 require "metanorma/cli/compiler"
 require "metanorma/cli/generator"
+require "metanorma/cli/git_template"
 
 module Metanorma
   module Cli
@@ -9,9 +10,10 @@ module Metanorma
       option :type, aliases: "-t", required: true, desc: "Document type"
       option :doctype, aliases: "-d", required: true, desc: "Metanorma doctype"
       option :overwrite, aliases: "-r", desc: "Overwrite existing document"
+      option :template, aliases: "-g", desc: "Git hosted remote template skeleton"
 
-      def new(document_name)
-        Metanorma::Cli::Generator.run(document_name, options.dup)
+      def new(name)
+        create_new_document(name, options.dup)
       end
 
       desc "compile FILENAME", "Compile to a metanorma document"
@@ -54,6 +56,16 @@ module Metanorma
         require "metanorma-#{type}"
         processor = Metanorma::Registry.instance.find_processor(type.to_sym)
         processor.version
+      end
+
+      def create_new_document(name, options)
+        Metanorma::Cli::Generator.run(
+          name,
+          type: options[:type],
+          doctype: options[:doctype],
+          template: options[:template],
+          overwrite: options[:overwrite],
+        )
       end
     end
   end

--- a/lib/metanorma/cli/git_template.rb
+++ b/lib/metanorma/cli/git_template.rb
@@ -1,0 +1,104 @@
+require "git"
+
+module Metanorma
+  module Cli
+    class GitTemplate
+      def initialize(name, options = {})
+        @name = name
+        @options = options
+      end
+
+      def remove!
+        remove_template
+        return true
+      end
+
+      def download
+        remove!
+        clone_git_template(options[:repo])
+
+      rescue Git::GitExecuteError
+        UI.say("Invalid template reoository!")
+        return nil
+      end
+
+      def find_or_download
+        find_template || download_template
+      end
+
+      # Find or Download
+      #
+      # This interface expects a name / type, and then it will
+      # find that template, or if non exist then it will download
+      # and return the downloaded path.
+      #
+      def self.find_or_download_by(name)
+        new(name).find_or_download
+      end
+
+      # Download a template
+      #
+      # This interface expects a name, and remote repository link
+      # for a template, then it will download that template and it
+      # will return the downloaded path.
+      #
+      # By default, downloaded tempaltes will be stored in a sub
+      # directoy inside metanorma's tempaltes directory, but if
+      # you don't want then you can set the `remote` to false.
+      #
+      def self.download(name, repo:, remote: true)
+        new(name, repo: repo, remote: remote).download
+      end
+
+      private
+
+      attr_reader :name, :options
+
+      def find_template
+        if template_path.exist?
+          template_path
+        end
+      end
+
+      def download_template
+        template_repo = git_repos[name.to_sym]
+
+        if template_repo
+          clone_git_template(template_repo)
+        end
+      end
+
+      def remove_template
+        if template_path.exist?
+          template_path.rmtree
+        end
+      end
+
+      def clone_git_template(repo)
+        clone = Git.clone(repo, name, path: templates_path)
+        template_path unless clone.nil?
+      end
+
+      def git_repos
+        @git_repos ||= {
+          csd: "https://github.com/metanorma/mn-templates-csd",
+          ogc: "https://github.com/metanorma/mn-templates-ogc",
+          iso: "https://github.com/metanorma/mn-templates-iso",
+        }
+      end
+
+      def templates_path
+        @templates_path ||= build_templates_path
+      end
+
+      def build_templates_path
+        sub_directory = options[:remote] == true ? "git" : nil
+        Metanorma::Cli.templates_path.join(sub_directory.to_s)
+      end
+
+      def template_path
+        @template_path ||= templates_path.join(name.to_s.downcase)
+      end
+    end
+  end
+end

--- a/metanorma-cli.gemspec
+++ b/metanorma-cli.gemspec
@@ -49,4 +49,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'isodoc', "~> 0.9.0"
   spec.add_runtime_dependency 'metanorma', "~> 0.3.9"
   spec.add_runtime_dependency 'nokogiri', ">= 1"
+  spec.add_runtime_dependency "git", "~> 1.5"
 end

--- a/spec/acceptance/new_spec.rb
+++ b/spec/acceptance/new_spec.rb
@@ -10,5 +10,30 @@ RSpec.describe "Metanorma" do
 
       expect(Metanorma::Cli::Generator).to have_received(:run)
     end
+
+    context "with :template option" do
+      it "downloads the template and create new document" do
+        allow(Metanorma::Cli::Generator).to receive(:run)
+
+        command = %w(
+          new
+            -t csd
+            -d standard
+            -g https://github.com/metanorma/mn-templates-csd
+            ./tmp/my-csd-doc
+        )
+
+        capture_stdout { Metanorma::Cli.start(command) }
+
+        expect(Metanorma::Cli::Generator).to have_received(:run).
+          with(
+            "./tmp/my-csd-doc",
+            doctype: "standard",
+            overwrite: nil,
+            template: "https://github.com/metanorma/mn-templates-csd",
+            type: "csd",
+        )
+      end
+    end
   end
 end

--- a/spec/metanorma/cli/generator_spec.rb
+++ b/spec/metanorma/cli/generator_spec.rb
@@ -2,13 +2,14 @@ require "spec_helper"
 
 RSpec.describe Metanorma::Cli::Generator do
   describe ".run" do
-    context "without existing templates" do
-      it "downloads and generate new document" do
+    context "default type templates" do
+      it "downloads and creates new document" do
         document = "./tmp/my-document"
 
         capture_stdout {
           Metanorma::Cli::Generator.run(
-            document, type: "csd", doctype: "standard", overwrite: true
+            document, type: "csd", doctype: "standard",
+            overwrite: true
           )
         }
 
@@ -17,6 +18,48 @@ RSpec.describe Metanorma::Cli::Generator do
         expect(file_exits?(document, "README.adoc")).to be_truthy
         expect(file_exits?(document, "cc-document.adoc")).to be_truthy
         expect(file_exits?(document, "sections/01-scope.adoc")).to be_truthy
+      end
+    end
+
+    context "with custom template" do
+      it "downloads and create new document" do
+        document = "./tmp/my-custom-csd"
+        template = "https://github.com/metanorma/mn-templates-csd"
+
+        capture_stdout {
+          Metanorma::Cli::Generator.run(
+            document,
+            type: "csd",
+            overwrite: true,
+            doctype: "standard",
+            template: template,
+          )
+        }
+
+        expect(file_exits?(document, "Gemfile")).to be_truthy
+        expect(file_exits?(document, "Makefile")).to be_truthy
+        expect(file_exits?(document, "README.adoc")).to be_truthy
+        expect(file_exits?(document, "cc-document.adoc")).to be_truthy
+        expect(file_exits?(document, "sections/01-scope.adoc")).to be_truthy
+      end
+    end
+
+    context "with invalid template" do
+      it "raise and throws an exception" do
+        document = "./tmp/my-invalid-document"
+        template = "https://github.com/metanorma/mn-templates-invalid"
+
+        output = capture_stdout {
+          Metanorma::Cli::Generator.run(
+            document,
+            type: "nncsd",
+            overwrite: true,
+            doctype: "standard",
+            template: template,
+          )
+        }
+
+        expect(output).to include("Sorry, could not generate the document!")
       end
     end
   end

--- a/spec/metanorma/cli/git_template_spec.rb
+++ b/spec/metanorma/cli/git_template_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+RSpec.describe Metanorma::Cli::GitTemplate do
+  describe ".find_or_download_by" do
+    context "with existing template" do
+      it "returns the existing template" do
+        Metanorma::Cli::GitTemplate.find_or_download_by("csd")
+
+        template = Metanorma::Cli::GitTemplate.find_or_download_by("csd")
+
+        expect(template.exist?).to be_truthy
+        expect(template.to_s).to include("templates/csd")
+      end
+    end
+
+    context "without an existing template" do
+      it "downloads and return the new template" do
+        Metanorma::Cli::GitTemplate.new("csd").remove!
+
+        template = Metanorma::Cli::GitTemplate.find_or_download_by("csd")
+
+        expect(template.exist?).to be_truthy
+        expect(template.to_s).to include("templates/csd")
+      end
+    end
+  end
+
+  describe ".download" do
+    it "downloads a remote metanorma template" do
+      csd_template = "https://github.com/metanorma/mn-templates-csd"
+
+      template = Metanorma::Cli::GitTemplate.download("csd", repo: csd_template)
+
+      expect(template.exist?).to be_truthy
+      expect(template.to_s).to include("templates/git/csd")
+    end
+
+    it "says it out loud for invalid template repository" do
+      template_repo = "https://github.com/metanorma/mn-templates-csd-one"
+
+      output = capture_stdout {
+        Metanorma::Cli::GitTemplate.download("csd", repo: template_repo)
+      }
+
+      expect(output).to include("Invalid template reoository!")
+    end
+  end
+end

--- a/spec/metanorma_spec.rb
+++ b/spec/metanorma_spec.rb
@@ -148,12 +148,10 @@ RSpec.describe "warns when bogus extension requested" do
   its(:stdout) { is_expected.to include "bogus_format format is not supported for this standard" }
 end
 
-# Maybe use the thor default error in this case?"
-#
-# RSpec.describe "warns when no file provided" do
-#   command "metanorma -t iso -x html"
-#   its(:stdout) { is_expected.to include "Need to specify a file to process" }
-# end
+RSpec.describe "warns when no file provided" do
+  command "metanorma -t iso -x html"
+  its(:stdout) { is_expected.to include "Need to specify a file to process" }
+end
 
 RSpec.describe "gives version information" do
   command "metanorma -v -t iso"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,11 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  config.before(:suite) do
+    tmp_dir = Pathname.new("./tmp")
+    FileUtils.mkdir_p(tmp_dir) unless tmp_dir.exist?
+  end
+
   config.include RSpecCommand
 end
 


### PR DESCRIPTION
Currently, we have some basic standard templates included with the CLI and user can only use any of those to create a new document, but in reality, we want the user to be able to provide custom template and use it to create a new document.

This commit adds that functionality, so a user can provide custom git template repository as CLI argument and metanorma will automatically download and use that template for document creation.

This also stores those template in the CLI, so in the future, if it's desirable then we can also use this cache version.