### PR TITLE
Include dot files in the base templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 /Gemfile.lock
 /templates/*
 !/templates/base
+/test.*
+/testrelaton.xml
+/extract/
 
 # rspec failure tracking
 .rspec_status

--- a/lib/metanorma/cli/generator.rb
+++ b/lib/metanorma/cli/generator.rb
@@ -106,7 +106,9 @@ module Metanorma
 
       def dir_files(*arguments)
         paths = [*arguments, "**", "**"].join("/")
-        Pathname.glob(paths).reject(&:directory?).map(&:to_s)
+        files = Pathname.glob(paths, File::FNM_DOTMATCH) - [".", " .."]
+
+        files.reject(&:directory?).map(&:to_s)
       end
 
       def ask_to_confirm(document)

--- a/spec/metanorma/cli/generator_spec.rb
+++ b/spec/metanorma/cli/generator_spec.rb
@@ -13,11 +13,8 @@ RSpec.describe Metanorma::Cli::Generator do
           )
         }
 
-        expect(file_exits?(document, "Gemfile")).to be_truthy
-        expect(file_exits?(document, "Makefile")).to be_truthy
-        expect(file_exits?(document, ".gitignore")).to be_truthy
+        expect_document_to_include_base_templates(document)
         expect(file_exits?(document, "README.adoc")).to be_truthy
-        expect(file_exits?(document, ".gitlab-ci.yml")).to be_truthy
         expect(file_exits?(document, "cc-document.adoc")).to be_truthy
         expect(file_exits?(document, "sections/01-scope.adoc")).to be_truthy
       end
@@ -38,8 +35,7 @@ RSpec.describe Metanorma::Cli::Generator do
           )
         }
 
-        expect(file_exits?(document, "Gemfile")).to be_truthy
-        expect(file_exits?(document, "Makefile")).to be_truthy
+        expect_document_to_include_base_templates(document)
         expect(file_exits?(document, "README.adoc")).to be_truthy
         expect(file_exits?(document, "cc-document.adoc")).to be_truthy
         expect(file_exits?(document, "sections/01-scope.adoc")).to be_truthy
@@ -68,5 +64,24 @@ RSpec.describe Metanorma::Cli::Generator do
 
   def file_exits?(root, filename)
     File.exist?([root, filename].join("/"))
+  end
+
+  def base_templates
+    @base_templates ||= [
+      "Gemfile",
+      "Makefile",
+      "deploy.sh",
+      ".gitignore",
+      ".travis.yml",
+      "Makefile.win",
+      "appveyor.yml",
+      ".gitlab-ci.yml",
+    ]
+  end
+
+  def expect_document_to_include_base_templates(document)
+    base_templates.each do |template|
+      expect(file_exits?(document, template)).to be_truthy, lambda { template }
+    end
   end
 end

--- a/spec/metanorma/cli/generator_spec.rb
+++ b/spec/metanorma/cli/generator_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe Metanorma::Cli::Generator do
 
         expect(file_exits?(document, "Gemfile")).to be_truthy
         expect(file_exits?(document, "Makefile")).to be_truthy
+        expect(file_exits?(document, ".gitignore")).to be_truthy
         expect(file_exits?(document, "README.adoc")).to be_truthy
+        expect(file_exits?(document, ".gitlab-ci.yml")).to be_truthy
         expect(file_exits?(document, "cc-document.adoc")).to be_truthy
         expect(file_exits?(document, "sections/01-scope.adoc")).to be_truthy
       end

--- a/templates/base/.gitignore
+++ b/templates/base/.gitignore
@@ -1,0 +1,16 @@
+.DS_Store
+.swp
+.tmp.xml
+
+# Output files
+csd-*.html
+csd-*.doc
+csd-*.xml
+csd-*_files
+document.html
+document.doc
+document.xml
+document.pdf
+
+# Deploy key
+deploy_key

--- a/templates/base/.gitlab-ci.yml
+++ b/templates/base/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+image:
+  name: ribose/metanorma
+  entrypoint: [""]
+
+cache:
+  paths:
+
+build:
+  stage: build
+  script:
+    - bundle
+    - make clean all publish
+  artifacts:
+    paths:
+      - published

--- a/templates/base/.travis.yml
+++ b/templates/base/.travis.yml
@@ -3,17 +3,20 @@ dist: xenial
 
 env:
   global:
-    - JAVA_OPTS="java.awt.headless=true"
-    - COMMIT_AUTHOR_EMAIL="travis-ci@calconnect.org"
+    - COMMIT_AUTHOR_EMAIL="travis-ci@example.org"
+
 rvm:
   - 2.5.3
+
 cache: bundler
 before_install:
   - gem update --system
   - gem install bundler
   - sudo bash -c "curl -L https://raw.githubusercontent.com/metanorma/metanorma-linux-setup/master/ubuntu.sh | bash"
+
 script:
   - make clean all publish
+
 deploy:
   provider: script
   script: bash -c "curl -L https://raw.githubusercontent.com/metanorma/metanorma-build-scripts/deploy-to-gh-pages.sh | bash"

--- a/templates/base/.travis.yml
+++ b/templates/base/.travis.yml
@@ -1,0 +1,21 @@
+language: ruby
+dist: xenial
+
+env:
+  global:
+    - JAVA_OPTS="java.awt.headless=true"
+    - COMMIT_AUTHOR_EMAIL="travis-ci@calconnect.org"
+rvm:
+  - 2.5.3
+cache: bundler
+before_install:
+  - gem update --system
+  - gem install bundler
+  - sudo bash -c "curl -L https://raw.githubusercontent.com/metanorma/metanorma-linux-setup/master/ubuntu.sh | bash"
+script:
+  - make clean all publish
+deploy:
+  provider: script
+  script: bash -c "curl -L https://raw.githubusercontent.com/metanorma/metanorma-build-scripts/deploy-to-gh-pages.sh | bash"
+  on:
+    branch: master


### PR DESCRIPTION
Currently, we do not include dot files in the base templates, but we actually do want to include those in document we generate, so this commit add those common files in this repo and this also do some modification do support this dot files.

Fixes #51