### PR TITLE
Gracefully fail for invalid commands

### DIFF
--- a/lib/metanorma/cli.rb
+++ b/lib/metanorma/cli.rb
@@ -54,6 +54,9 @@ module Metanorma
       end
 
       Metanorma::Cli::Command.start(arguments)
+
+    rescue Errno::ENOENT => error
+      UI.say("Error: #{error}, \nNot sure what to run? try: metanorma help")
     end
 
     def self.root


### PR DESCRIPTION
Since, we have invoked our custom command as root command, so every single command is going through our main compile command and this shouting out loud in the console.

This commit changes this behavior, so if user pass an invalid command or that's not a document name then it will show the error and suggest them to use the `metanorma help` instead.

Fixes #52