### PR TITLE
Do not ignore generated document files for deployment

### DIFF
--- a/templates/base/.gitignore
+++ b/templates/base/.gitignore
@@ -2,10 +2,5 @@
 .swp
 .tmp.xml
 
-# Output files
-document.html
-document.pdf
-document.xml
-
 # Deploy key
 deploy_key


### PR DESCRIPTION
If `document.*` is in the `.gitignore` file, we cannot deploy these files to GitHub pages. We cannot ignore those files.