### PR TITLE
Fix require library `(-r)` issue

### DIFF
--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -9,7 +9,7 @@ module Metanorma
       desc "new NAME", "Create new Metanorma document"
       option :type, aliases: "-t", required: true, desc: "Document type"
       option :doctype, aliases: "-d", required: true, desc: "Metanorma doctype"
-      option :overwrite, aliases: "-r", desc: "Overwrite existing document"
+      option :overwrite, aliases: "-y", type: :boolean, desc: "Overwrite existing document"
       option :template, aliases: "-l", desc: "Git hosted remote or local FS template skeleton"
 
       def new(name)
@@ -20,7 +20,7 @@ module Metanorma
       option :type, aliases: "-t", desc: "Type of standard to generate"
       option :extensions, aliases: "-x", type: :string, desc: "Type of extension to generate per type"
       option :format, aliases: "-f", default: :asciidoc, desc: "Format of source file: eg. asciidoc"
-      option :require, aliases: "-r", type: :array, desc: "Require LIBRARY prior to execution"
+      option :require, aliases: "-r", desc: "Require LIBRARY prior to execution"
       option :wrapper, aliases: "-w", type: :boolean, desc: "Create wrapper folder for HTML output"
       option :asciimath, aliases: "-a", type: :boolean, desc: "Keep Asciimath in XML output instead of converting it to MathM"
       option :datauriimage, aliases: "-d", type: :boolean, desc: "Encode HTML output images as data URIs"

--- a/lib/metanorma/cli/compiler.rb
+++ b/lib/metanorma/cli/compiler.rb
@@ -4,8 +4,7 @@ module Metanorma
       def initialize(file, options)
         @file = file
         @options = options
-        @extract = (options.delete(:extract) || "").split(",")
-        @extensions = (options.delete(:extensions) || "").split(",")
+        normalize_special_options
       end
 
       def compile
@@ -50,6 +49,12 @@ module Metanorma
             hash[key.to_sym] = value unless value.nil?
           end
         end
+      end
+
+      def normalize_special_options
+        @extract = (options.delete(:extract) || "").split(",")
+        @extensions = (options.delete(:extensions) || "").split(",") 
+        options[:require] = [options[:require]] if options[:require]
       end
     end
   end

--- a/spec/metanorma_spec.rb
+++ b/spec/metanorma_spec.rb
@@ -121,8 +121,22 @@ end
     OUTPUT
   end
 
-end
+  context "with -r option specified" do
+    it "loads the libary and compile document" do
+      File.open("test.adoc", "w:UTF-8") { |f| f.write(ASCIIDOC_PREAMBLE_HDR) }
+      FileUtils.rm_f %w(test.xml test.html test.alt.html test.doc)
 
+      system "metanorma compile -t iso -r metanorma-iso test.adoc"
+
+      expect(File.exist?("test.xml")).to be true
+      expect(File.exist?("test.doc")).to be false
+      expect(File.exist?("test.html")).to be true
+      expect(File.exist?("test.alt.html")).to be false
+      xml = File.read("test.xml")
+      expect(xml).to include "</iso-standard>"
+    end
+  end
+end
 
 RSpec.describe "warns when no standard type provided" do
   file "test.adoc", ASCIIDOC_CONFIGURED_HDR


### PR DESCRIPTION
In document compilation we missed the `require` options, and it was not behaving as expected and introduced issue like 49. This commit fixes this so this should work as expected from now on.

This also updates the existing `overwrite` options, it removes the aliases and also changes it to be a straight forward flag.

Fixes #49