### PR TITLE
Return correct exit code on failure

### DIFF
--- a/lib/metanorma/cli.rb
+++ b/lib/metanorma/cli.rb
@@ -57,6 +57,7 @@ module Metanorma
 
     rescue Errno::ENOENT => error
       UI.say("Error: #{error}, \nNot sure what to run? try: metanorma help")
+      exit(Errno::ENOENT::Errno)
     end
 
     def self.root

--- a/spec/acceptance/compile_spec.rb
+++ b/spec/acceptance/compile_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe "Metanorma" do
     end
   end
 
+  describe "failure" do
+    it "returns the correct status code" do
+      begin
+        command = %w(compile -t iso invalid-file)
+        capture_stdout { Metanorma::Cli.start(command) }
+
+      rescue SystemExit => error
+        expect(error.status).to eq(Errno::ENOENT::Errno)
+      end
+    end
+  end
+
   def sample_asciidoc_file
     @sample_asciidoc_file ||=
       Metanorma::Cli.root_path.

--- a/spec/metanorma_spec.rb
+++ b/spec/metanorma_spec.rb
@@ -157,4 +157,3 @@ RSpec.describe "gives version information" do
   command "metanorma -v -t iso"
   its(:stdout) { is_expected.to match(/Metanorma::ISO \d/) }
 end
-


### PR DESCRIPTION
Currently we aren't returning the correct status code when the CLI fails to execute a command. Regardless, of the status it always returns a `0` status code, and that introduced issues like 74.

This commit adds the necessary changes, so the CLII return's the correct exit codes on failure.

Fixes #74