### PR TITLE
Add interface to list supported extensions

### DIFF
--- a/lib/metanorma/cli.rb
+++ b/lib/metanorma/cli.rb
@@ -88,7 +88,7 @@ module Metanorma
 
     def self.find_command(arguments)
       commands = Metanorma::Cli::Command.all_commands.keys
-      commands.select { |cmd| arguments.include?(cmd) == true }
+      commands.select { |cmd| arguments.include?(cmd.gsub("_", "-")) == true }
     end
   end
 end

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -49,16 +49,27 @@ module Metanorma
 
       def version
         if options[:format] == :asciidoc
-          UI.say(find_version(options[:type]))
+          UI.say(find_backend(options[:type].to_sym).version)
         end
+      end
+
+      desc "list-extensions TYPE", "List supported extensions"
+      def list_extensions(type)
+        output_formats = find_backend(type).output_formats
+        UI.say("Supported extensions: #{join_keys(output_formats.keys)}.")
+      rescue LoadError
+        UI.say("Couldn't load #{type}, please provide a valid type!")
       end
 
       private
 
-      def find_version(type)
+      def find_backend(type)
         require "metanorma-#{type}"
-        processor = Metanorma::Registry.instance.find_processor(type.to_sym)
-        processor.version
+        Metanorma::Registry.instance.find_processor(type.to_sym)
+      end
+
+      def join_keys(keys)
+        [keys[0..-2].join(", "), keys.last].join(" and ")
       end
 
       def create_new_document(name, options)

--- a/spec/acceptance/list_extensions_spec.rb
+++ b/spec/acceptance/list_extensions_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe "Metanorma" do
+  describe "list-extensions" do
+    it "lists available extensions for a type" do
+      command = %w(list-extensions iso)
+      output = capture_stdout { Metanorma::Cli.start(command) }
+
+      expect(output).to include("Supported extensions: xml, rxl, html")
+    end
+
+    it "gracefully handles invalid types" do
+      command = %w(list-extensions iso-invalid)
+      output = capture_stdout { Metanorma::Cli.start(command) }
+
+      expect(output).to include("Couldn't load iso-invalid, please provide")
+    end
+  end
+end


### PR DESCRIPTION
Currently, we do not have any easier way for user to know the supported extensions for a type. Which might actually confuse.

This commit adds an interface, which allows a user to retrieve the list of supported extensions for a type. For example: if you want to check the supported extensions for `iso` then you can use the following.

```
metanorma list-extensions iso
```

Closes: #76