### PR TITLE
List supported extensions for all type

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -149,6 +149,26 @@ This should compile any valid document, but if there are some issues then it
 will also print those out in the terminal. Currently, the supported flavors
 are `ietf`, `iso`, `gb`, `csd`, `csand`, `m3d` and `rsd`.
 
+=== Displaying supported extensions (`metanorma list-extensions`)
+
+Having hard time figuring out what extensions is supported or not? Well, we've
+got you covered, if you know the type you are looking for then simply use the
+follwoing command:
+
+[source, sh]
+----
+metanorma list-extensions iso
+----
+
+This will display all the extension this type supports, and if you want to check
+all available extensions for all types, then you can run the same commad without
+specifying the type, and it will display all available extensions.
+
+[source, sh]
+
+----
+metanorma list-extensions
+----
 
 
 === Displaying Metanorma processor version (`metanorma version`)

--- a/README.adoc
+++ b/README.adoc
@@ -38,7 +38,7 @@ for advanced details regarding dependencies and Windows installation notes.
 
 == Usage
 
-=== Generating a new Metanorma document using a template  (`metanorma new`)
+=== Generate a new Metanorma document using a template  (`metanorma new`)
 
 Metanorma CLI allows you to create a new document using an official
 template, or a user-specified custom template.
@@ -149,29 +149,39 @@ This should compile any valid document, but if there are some issues then it
 will also print those out in the terminal. Currently, the supported flavors
 are `ietf`, `iso`, `gb`, `csd`, `csand`, `m3d` and `rsd`.
 
-=== Displaying supported extensions (`metanorma list-extensions`)
 
-Having hard time figuring out what extensions is supported or not? Well, we've
-got you covered, if you know the type you are looking for then simply use the
-follwoing command:
+=== List supported output formats (`metanorma list-extensions`)
 
-[source, sh]
-----
-metanorma list-extensions iso
-----
+Need to know what output formats are supported for a given flavor?
+We've got you covered.
 
-This will display all the extension this type supports, and if you want to check
-all available extensions for all types, then you can run the same commad without
-specifying the type, and it will display all available extensions.
+To list out the output formats supported by every single flavor type,
+run the following command:
 
-[source, sh]
+[source,sh]
 
 ----
 metanorma list-extensions
 ----
 
 
-=== Displaying Metanorma processor version (`metanorma version`)
+To list out the output formats supported by a particular flavor type,
+run the following command:
+
+[source,sh]
+----
+metanorma list-extensions <flavor>
+----
+
+e.g.,
+
+[source,sh]
+----
+metanorma list-extensions iso
+----
+
+
+=== Show processor version (`metanorma version`)
 
 The `version` command returns the version of the Metanorma processor for
 a specific flavor.

--- a/lib/metanorma/cli.rb
+++ b/lib/metanorma/cli.rb
@@ -4,7 +4,6 @@ require "metanorma/cli/command"
 
 module Metanorma
   module Cli
-
     SUPPORTED_GEMS = [
       "metanorma-iso",
       "metanorma-ietf",

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -53,15 +53,34 @@ module Metanorma
         end
       end
 
-      desc "list-extensions TYPE", "List supported extensions"
-      def list_extensions(type)
-        output_formats = find_backend(type).output_formats
-        UI.say("Supported extensions: #{join_keys(output_formats.keys)}.")
+      desc "list-extensions", "List supported extensions"
+      def list_extensions(type = nil)
+        single_type_extensions(type) || all_type_extensions
       rescue LoadError
         UI.say("Couldn't load #{type}, please provide a valid type!")
       end
 
       private
+
+      def single_type_extensions(type)
+        if type
+          format_keys = find_backend(type).output_formats.keys
+          UI.say("Supported extensions: #{join_keys(format_keys)}.")
+          return true
+        end
+      end
+
+      def all_type_extensions
+        Metanorma::Cli.load_flavors
+
+        message = "Supported extensions per type: \n"
+        Metanorma::Registry.instance.processors.each do |type_sym, processor|
+          format_keys = processor.output_formats.keys
+          message += "  #{type_sym}: #{join_keys(format_keys)}.\n"
+        end
+
+        UI.say(message)
+      end
 
       def find_backend(type)
         require "metanorma-#{type}"

--- a/spec/acceptance/list_extensions_spec.rb
+++ b/spec/acceptance/list_extensions_spec.rb
@@ -9,6 +9,15 @@ RSpec.describe "Metanorma" do
       expect(output).to include("Supported extensions: xml, rxl, html")
     end
 
+    it "lists all extensions if no type specified" do
+      command = %w(list-extensions)
+      output = capture_stdout { Metanorma::Cli.start(command) }
+
+      expect(output).to include("iso: xml, rxl, html")
+      expect(output).to include("csd: xml, rxl, html, pdf")
+      expect(output).to include("ietf: xmlrfc2, xmlrfc3, html")
+    end
+
     it "gracefully handles invalid types" do
       command = %w(list-extensions iso-invalid)
       output = capture_stdout { Metanorma::Cli.start(command) }


### PR DESCRIPTION
The CLI offers `list-extensions type` interface to display all supported extensions for a specific type, but we want to extend this feature.

This commit improve this interface, so if the user specify a single type then it will display supported extensions for that specific type, but if they don't then it will display all of the supported extensions. Usages:

```sh
metanorma list-extensions
```

Closes #78