### PR TITLE
Add interface to store user's template

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -195,6 +195,17 @@ using for that specific processor.
 metanorma version --type iso
 ----
 
+=== Add new template repository (`metanorma template-repo add`)
+
+The `template-repo add` interface allows you to add your custom template
+repository to metanorma, so next time when you need to generate a new document
+then you can directly use that name to use your custom template from that
+repository.
+
+[source, sh]
+----
+metanorma template-repo add my-iso https://github.com/you/my-iso-template
+----
 
 == Credits
 

--- a/lib/metanorma/cli.rb
+++ b/lib/metanorma/cli.rb
@@ -1,5 +1,6 @@
 require "metanorma"
 require "metanorma/cli/version"
+require "metanorma/cli/errors"
 require "metanorma/cli/command"
 
 module Metanorma
@@ -68,7 +69,11 @@ module Metanorma
     end
 
     def self.templates_path
-      Pathname.new(Dir.home).join(".metanorma", "templates")
+      home_directory.join("templates")
+    end
+
+    def self.home_directory
+      Pathname.new(Dir.home).join(".metanorma")
     end
 
     def self.writable_templates_path?

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -2,6 +2,7 @@ require "thor"
 require "metanorma/cli/compiler"
 require "metanorma/cli/generator"
 require "metanorma/cli/git_template"
+require "metanorma/cli/commands/template_repo"
 
 module Metanorma
   module Cli
@@ -59,6 +60,9 @@ module Metanorma
       rescue LoadError
         UI.say("Couldn't load #{type}, please provide a valid type!")
       end
+
+      desc "template-repo", "Manage metanorma templates repository"
+      subcommand :template_repo, Metanorma::Cli::Commands::TemplateRepo
 
       private
 

--- a/lib/metanorma/cli/commands/template_repo.rb
+++ b/lib/metanorma/cli/commands/template_repo.rb
@@ -1,0 +1,20 @@
+require "metanorma/cli/template_repo"
+
+module Metanorma
+  module Cli
+    module Commands
+      class TemplateRepo < Thor
+        desc "add NAME SOURCE", "Add new metanorma templates repository"
+        option :overwrite, aliases: "-y", type: :boolean, desc: "Overwrite existing template"
+
+        def add(name, source)
+          Metanorma::Cli::TemplateRepo.add(name, source, options)
+          UI.say("Template repo: #{name} has been added successfully")
+
+        rescue Errors::DuplicateTemplateError
+          UI.error("Duplicate metanorma template")
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/cli/errors.rb
+++ b/lib/metanorma/cli/errors.rb
@@ -1,0 +1,8 @@
+module Metanorma
+  module Cli
+    module Errors
+      class DuplicateTemplateError < StandardError
+      end
+    end
+  end
+end

--- a/lib/metanorma/cli/template_repo.rb
+++ b/lib/metanorma/cli/template_repo.rb
@@ -1,0 +1,62 @@
+require "yaml"
+
+module Metanorma
+  module Cli
+    class TemplateRepo
+      def initialize(options = {})
+        @name = options.fetch(:name)
+        @source = options.fetch(:source)
+        @type = options.fetch(:type, "custom")
+        @overwrite = options.fetch(:overwrite, false)
+      end
+
+      def add
+        create_template_config
+        add_new_template(name, source, type)
+        write_to_template_config(templates)
+
+        templates[:templates]
+      end
+
+      def self.add(name, source, options = {})
+        new(options.merge(name: name, source: source)).add
+      end
+
+      private
+
+      attr_reader :name, :source, :type, :overwrite
+
+      def templates
+        @templates ||= YAML.load(template_config_file.read)
+      end
+
+      def template_config_file
+        @template_config_file ||= Cli.home_directory.join("config.yml")
+      end
+
+      def create_template_config
+        unless template_config_file.exist?
+          unless template_config_file.dirname.exist?
+            FileUtils.mkdir_p(template_config_file.dirname)
+          end
+
+          write_to_template_config({templates: []})
+        end
+      end
+
+      def write_to_template_config(templates)
+        File.write(template_config_file, templates.to_yaml)
+      end
+
+      def add_new_template(name, source, type)
+        names = templates[:templates].map { |template| template[:name].to_s }
+
+        if names.include?(name.to_s) && overwrite == false
+          raise Errors::DuplicateTemplateError.new("Duplicate metanorma template")
+        end
+
+        templates[:templates].push({ name: name, source: source, type: type })
+      end
+    end
+  end
+end

--- a/lib/metanorma/cli/ui.rb
+++ b/lib/metanorma/cli/ui.rb
@@ -11,6 +11,10 @@ module Metanorma
         new.say(message)
       end
 
+      def self.error(message)
+        new.error(message)
+      end
+
       def self.run(command)
         require "open3"
         Open3.capture3(command)

--- a/spec/acceptance/add_template_repo_spec.rb
+++ b/spec/acceptance/add_template_repo_spec.rb
@@ -1,0 +1,24 @@
+require "yaml"
+require "spec_helper"
+
+RSpec.describe "Metanorma" do
+  describe "template-repo add" do
+    it "adds a new template to metanorma config" do
+      stub_system_home_directory
+
+      command = %w( template-repo add my-iso -y https://github.com/metanorma/mn-iso)
+      output = capture_stdout { Metanorma::Cli.start(command) }
+
+      expect(output).to include("Template repo: my-iso has been added successfully")
+    end
+
+    it "returns error for duplicate template" do
+      stub_system_home_directory
+
+      command = %w( template-repo add my-iso https://github.com/metanorma/mn-iso)
+      output = capture_stderr { Metanorma::Cli.start(command) }
+
+      expect(output).to include("Duplicate metanorma template")
+    end
+  end
+end

--- a/spec/metanorma/cli/template_repo_spec.rb
+++ b/spec/metanorma/cli/template_repo_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+RSpec.describe Metanorma::Cli::TemplateRepo do
+  describe ".add" do
+    context "with valid template source" do
+      it "adds the template to metanorma templates" do
+        name = "iso"
+        source = "https://github.com/metanorma/mn-templates-iso"
+        stub_system_home_directory
+
+        templates = Metanorma::Cli::TemplateRepo.add(
+          name, source, overwrite: true,
+        )
+
+        expect(templates.last[:name]).to eq(name)
+        expect(templates.last[:source]).to eq(source)
+      end
+    end
+
+    context "with duplicate template" do
+      it "does override the existing template" do
+        name = "iso"
+        source = "https://github.com/metanorma/mn-templates-iso"
+
+        expect do
+          Metanorma::Cli::TemplateRepo.add(name, source)
+          Metanorma::Cli::TemplateRepo.add(name, source)
+        end.to raise_error(Metanorma::Cli::Errors::DuplicateTemplateError)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
   config.include Metanorma::ConsoleHelper
+  config.include Metanorma::Helper
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/spec/support/metanorma_helper.rb
+++ b/spec/support/metanorma_helper.rb
@@ -1,0 +1,7 @@
+module Metanorma
+  module Helper
+    def stub_system_home_directory
+      allow(Dir).to receive(:home).and_return(Metanorma::Cli.root_path.join("tmp"))
+    end
+  end
+end


### PR DESCRIPTION
Currently, we are allowing user to use their template to generate a new document, but they need to provide the repo details every time they want to create a new document using that template.

Which is quite repetitive for some user, so this commit tries to simplify that process, and now they can store those template and later they will only need to provide the name and metanorma will automatically find the other details.

This commit only added the configuration setup for now, up next we are actually gonna use this configuration during generation.

```sh
metanorma template add my-iso https://github.com/you/my-iso-template
```

Related: #66