### PR TITLE
Remove old codes from the executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /templates/*
 !/templates/base
 /test.*
+/test
 /testrelaton.xml
 /extract/
 

--- a/exe/metanorma
+++ b/exe/metanorma
@@ -1,151 +1,20 @@
 #!/usr/bin/env ruby
+# encoding: UTF-8
 
-# Note
-#
-# Currently, we are developing a new version for this CLI, and
-# to test it out we adding this environment variable. When the
-# `METANORMA_DEV_MODE` set to `true` then it will revert to the
-# old version of the CLI.
-#
-unless ENV.fetch("METANORMA_DEV_MODE", false) == "true"
-  require "bundler/setup"
-  require "metanorma/cli"
+# resolve bin path, ignoring symlinks
+require "pathname"
+bin_file = Pathname.new(__FILE__).realpath
 
-  Metanorma::Cli.start(ARGV)
-  exit 0
+# add self to libpath
+$:.unshift File.expand_path("../../lib", bin_file)
+
+# Fixes https://github.com/rubygems/rubygems/issues/1420
+require "rubygems/specification"
+
+class Gem::Specification
+  def this; self; end
 end
 
-require "optparse"
-require "metanorma"
-require "fileutils"
-require "nokogiri"
-require "metanorma-cli"
-
-registry = Metanorma::Registry.instance
-Metanorma::Cli.load_flavors
-
-options = {
-  format: :asciidoc
-}
-opt_parser = OptionParser.new do |opts|
-  opts.banner += " <file>"
-  opts.on(
-    '-t',
-    '--type TYPE',
-    String,
-    "Type of standard to generate",
-    "#{registry.supported_backends}"
-  ) { |v| options[:type] = v.to_sym }
-
-  output_formats = registry.output_formats.inject([]) do |acc, (processor, formats)|
-    str = "* #{processor.to_s}: "
-
-    formats.each_pair do |type, ext|
-      str << "['#{type.to_s}': #{ext.to_s}] "
-    end
-
-    acc << str
-  end
-
-  opts.on(
-    '-x',
-    "--extensions all | EXT,...",
-    Array,
-    "Document extensions available per type (type, ['filetype': ext])",
-    *output_formats
-  ) { |v| options[:extension_keys] = v.map(&:to_sym) }
-
-  input_formats = [:asciidoc]
-  opts.on(
-    '-f',
-    '--format FORMAT',
-    String,
-    'Format of source file',
-    "#{input_formats}",
-  ) { |v| options[:format] = v.to_sym }
-
-  opts.on(
-    '-r',
-    '--require LIBRARY',
-    'Require LIBRARY prior to execution'
-  ) { |v|
-    options[:require] ||= []
-    options[:require] << v
-  }
-
-  opts.on(
-    '-v',
-    '--version',
-    "Print version of code (accompanied with -t)",
-  ) { options[:version] = true }
-
-  opts.on(
-    '-w',
-    '--wrapper',
-    'Create wrapper folder for HTML output'
-  ) { options[:wrapper] = true }
-
-  opts.on(
-    '-a',
-    '--asciimath',
-    'Keep Asciimath in XML output instead of converting it to MathML'
-  ) { options[:asciimath] = true }
-
-  opts.on(
-    '-d',
-    '--data-uri-image',
-    'Encode HTML output images as data URIs'
-  ) { options[:datauriimage] = true }
-
-  opts.on(
-    '-R',
-    '--relaton FILENAME',
-    'Export Relaton XML for document to nominated filename'
-  ) { |v| options[:relaton] = v }
-
-  opts.on(
-    '-e',
-    '--extract DIR(,ASSET1,ASSET2...)',
-    Array,
-    'Export sourcecode fragments from this document to nominated directory. If ASSET1,ASSET2 are named, only those types of asset are extracted'
-  ) do |v|
-    options[:extract] = v[0]
-    options[:extract_type] = []
-    v.size > 1 and options[:extract_type] = v[1..-1].map(&:to_sym)
-  end
-
-  opts.on_tail("-h", "--help", "Show this message") do
-    puts opts
-    exit
-  end
-
-end
-
-opt_parser.parse!(ARGV)
-
-=begin
-if options[:require]
-  options[:require].each do |r|
-    require r
-  end
-end
-=end
-
-if options[:version]
-  case options[:format]
-  when :asciidoc
-    processor = registry.find_processor(options[:type].to_sym)
-    puts processor.version
-    exit
-  end
-end
-
-options[:filename] = ARGV.pop
-
-unless options[:filename]
-  puts "[metanorma] Error: Need to specify a file to process."
-  exit 0
-end
-
-filename = options[:filename]
-Metanorma::Compile.new().compile(filename, options)
+# start up the CLI
+require "metanorma/cli"
+Metanorma::Cli.start(ARGV)

--- a/spec/metanorma_spec.rb
+++ b/spec/metanorma_spec.rb
@@ -160,12 +160,6 @@ RSpec.describe "warns when bogus format requested" do
   its(:stdout) { is_expected.to include "Only source file format currently supported is 'asciidoc'" }
 end
 
-RSpec.describe "warns when bogus extension requested" do
-  file "test.adoc", ASCIIDOC_CONFIGURED_HDR
-  command "metanorma -t iso -x bogus_format test.adoc"
-  its(:stdout) { is_expected.to include "bogus_format format is not supported for this standard" }
-end
-
 RSpec.describe "warns when no file provided" do
   command "metanorma -t iso -x html"
   its(:stdout) { is_expected.to include "Need to specify a file to process" }


### PR DESCRIPTION
There was some major migration in the CLI lately, but we kept some of the existing codes as there was an way to switch back to that one using an environment variable.

But since the new version has been published for a while now and it is stable, so this commit removes those existing code form the library.

Closes #47