### PR TITLE
Do not exclude dofiles during packaging

### DIFF
--- a/metanorma-cli.gemspec
+++ b/metanorma-cli.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://www.metanorma.com"
   spec.license       = "BSD-2-Clause"
 
-  spec.files         = Dir['**/*'].reject { |f| f.match(%r{^(test|spec|features|.git)/|.(gem|gif|png|jpg|jpeg|xml|html|doc|pdf|dtd|ent)$}) }
-
+  spec.files         = Dir['**/*'].reject { |f| f.match(%r{^(test|spec|features|templates|.git)/|.(gem|gif|png|jpg|jpeg|xml|html|doc|pdf|dtd|ent)$}) }
+  spec.files        += Dir.glob("templates/base/**", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
 
   spec.extra_rdoc_files = %w[README.adoc LICENSE]
   spec.bindir        = "exe"


### PR DESCRIPTION
Currently, our gemspec is excluding all dotfiles, so whenever we try to use the bundled version then it doesn't generate those file. This commit explicitly include those dotfiles so it should work as expected.

Fixes: #91