### PR TITLE
Fix inconsistency for version interface

### DIFF
--- a/spec/acceptance/version_spec.rb
+++ b/spec/acceptance/version_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe "Metanorma" do
+  describe "version" do
+    context "with argument" do
+      it "display version for that backend" do
+        command = %w(version -t iso)
+        output = capture_stdout { Metanorma::Cli.start(command) }
+
+        expect(output).to include("Metanorma::ISO #{Metanorma::ISO::VERSION}")
+      end
+    end
+
+    context "without any argument" do
+      it "display version for dependencies" do
+        command = %w(version)
+        output = capture_stdout { Metanorma::Cli.start(command) }
+
+        expect(output).to include("Metanorma::ISO #{Metanorma::ISO::VERSION}")
+        expect(output).to include("Metanorma::Csd #{Metanorma::Csd::VERSION}")
+        expect(output).to include("Metanorma::Ietf #{Metanorma::Ietf::VERSION}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is some inconsistency in the `version` interface, one of command shows version for default backend, but other don't.

This commits to changes this, so if the user doesn't provide any type, it will display versions for all supported dependencies. But the user can also retrieve a specific version by adding it to the type option.

Related: #98