### PR TITLE
Disable git http authentication for rspec

### DIFF
--- a/lib/metanorma/cli.rb
+++ b/lib/metanorma/cli.rb
@@ -58,7 +58,7 @@ module Metanorma
 
       Metanorma::Cli::Command.start(arguments)
 
-    rescue Errno::ENOENT => error
+    rescue Errors::FileNotFoundError => error
       UI.say("Error: #{error}, \nNot sure what to run? try: metanorma help")
       exit(Errno::ENOENT::Errno)
     end

--- a/lib/metanorma/cli/compiler.rb
+++ b/lib/metanorma/cli/compiler.rb
@@ -1,3 +1,5 @@
+require "metanorma/cli/errors"
+
 module Metanorma
   module Cli
     class Compiler
@@ -13,6 +15,8 @@ module Metanorma
 
       def self.compile(file, options)
         new(file, options).compile
+      rescue Errno::ENOENT
+        raise Errors::FileNotFoundError
       end
 
       private

--- a/lib/metanorma/cli/errors.rb
+++ b/lib/metanorma/cli/errors.rb
@@ -1,8 +1,9 @@
 module Metanorma
   module Cli
     module Errors
-      class DuplicateTemplateError < StandardError
-      end
+      class DuplicateTemplateError < StandardError; end
+
+      class FileNotFoundError < StandardError; end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,13 @@ RSpec.configure do |config|
   config.before(:suite) do
     tmp_dir = Pathname.new("./tmp")
     FileUtils.mkdir_p(tmp_dir) unless tmp_dir.exist?
+
+    # Disable http authentication
+    ENV["GIT_TERMINAL_PROMPT"] = "0"
+  end
+
+  config.after(:suite) do
+    ENV["GIT_TERMINAL_PROMPT"] = "1"
   end
 
   config.include RSpecCommand


### PR DESCRIPTION
Running the test suite prompt the git http authentication dialog and it hangs there until we actually provide some input. But in reality we are only using public repo for the test suite, so lets disable the http authentication for now.

So, from now on our test suite won't prompt http authentication dialog anymore, even if the user doesn't have anything configured

Fixes #107