### PR TITLE
Add setup interface to install required fonts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,13 @@ AllCops:
   DisplayCopNames: false
   StyleGuideCopsOnly: false
   TargetRubyVersion: 2.4
-require:
-- rubocop-rails
-- rubocop-performance
+
+# Disableing for now
+#
+# require:
+#  - rubocop-rails
+#  - rubocop-performance
+#
 Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false

--- a/lib/metanorma/cli.rb
+++ b/lib/metanorma/cli.rb
@@ -21,6 +21,19 @@ module Metanorma
       "metanorma-itu",
     ]
 
+    # @TODO: Note
+    #
+    # This is temporary, we are going to extend this to
+    # each of the metanorma gem, so they can specifcy their
+    # own font requirements.
+    #
+    # Please add the whole set here.
+    #
+    REQUIRED_FONTS = [
+      "CALIBRI.TTF",
+      "CAMBRIA.TTC",
+    ].freeze
+
     PRIVATE_SUPPORTED_GEMS = ["metanorma-rsd", "metanorma-mpfd"]
 
     def self.load_flavors(flavor_names = SUPPORTED_GEMS + PRIVATE_SUPPORTED_GEMS)
@@ -78,6 +91,14 @@ module Metanorma
 
     def self.home_directory
       Pathname.new(Dir.home).join(".metanorma")
+    end
+
+    def self.fonts_directory
+      Metanorma::Cli.home_directory.join("fonts")
+    end
+
+    def self.fonts
+      Dir.glob(Metanorma::Cli.fonts_directory.join("**"))
     end
 
     def self.writable_templates_path?

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -1,4 +1,5 @@
 require "thor"
+require "metanorma/cli/setup"
 require "metanorma/cli/compiler"
 require "metanorma/cli/generator"
 require "metanorma/cli/git_template"
@@ -64,6 +65,24 @@ module Metanorma
 
       desc "template-repo", "Manage metanorma templates repository"
       subcommand :template_repo, Metanorma::Cli::Commands::TemplateRepo
+
+      desc "setup", "Initial necessary setup"
+      option(
+        :agree_to_terms,
+        type: :boolean,
+        required: false,
+        default: false,
+        desc: "Aggree / Disagree to licensing terms",
+      )
+
+      def setup
+        Metanorma::Cli::REQUIRED_FONTS.each do |font|
+          Metanorma::Cli::Setup.run(
+            font: font,
+            term_agreement: options[:agree_to_terms],
+          )
+        end
+      end
 
       private
 

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -72,7 +72,7 @@ module Metanorma
         type: :boolean,
         required: false,
         default: false,
-        desc: "Aggree / Disagree to licensing terms",
+        desc: "Agree / Disagree with all third-party licensing terms presented (WARNING: do know what you are agreeing with!)",
       )
 
       def setup
@@ -87,11 +87,11 @@ module Metanorma
       private
 
       def single_type_extensions(type)
-        if type
-          format_keys = find_backend(type).output_formats.keys
-          UI.say("Supported extensions: #{join_keys(format_keys)}.")
-          return true
-        end
+        return false unless type
+
+        format_keys = find_backend(type).output_formats.keys
+        UI.say("Supported extensions: #{join_keys(format_keys)}.")
+        true
       end
 
       def all_type_extensions

--- a/lib/metanorma/cli/setup.rb
+++ b/lib/metanorma/cli/setup.rb
@@ -1,0 +1,80 @@
+require "fontist"
+require "fileutils"
+
+module Metanorma
+  module Cli
+    class Setup
+      def initialize(options)
+        @options = options
+        @font_name = options.fetch(:font)
+        @term_agreement = options.fetch(:term_agreement, false)
+
+        create_metanorma_fonts_directory
+      end
+
+      def self.run(options = {})
+        new(options).run
+      end
+
+      def run
+        font = Metanorma::Cli.fonts.grep(/#{font_name}/i)
+
+        if font.empty?
+          font_paths = download_font
+          copy_to_fonts(font_paths)
+        end
+      end
+
+      private
+
+      attr_reader :font_name, :options, :term_agreement
+
+      def create_metanorma_fonts_directory
+        unless Metanorma::Cli.fonts_directory.exist?
+          FileUtils.mkdir_p(Metanorma::Cli.fonts_directory)
+        end
+      end
+
+      def metanorma_fonts_path
+        @metanorma_fonts_path ||= Metanorma::Cli.fonts_directory
+      end
+
+      def download_font
+        Fontist::Finder.find(font_name)
+      rescue Fontist::Errors::MissingFontError
+        ask_user_and_download_font(font_name)
+      end
+
+      def copy_to_fonts(fonts_path)
+        fonts_path.each do |font_path|
+          font_name = File.basename(font_path)
+          FileUtils.copy_file(font_path, metanorma_fonts_path.join(font_name))
+        end
+      end
+
+      def ask_user_and_download_font(font_name)
+        response = term_agreement ? "yes" : "no"
+
+        if !term_agreement
+          response = UI.ask(message.strip)
+        end
+
+        if response.downcase === "yes"
+          Fontist::Installer.download(font_name, confirmation: response)
+        end
+      end
+
+      def message
+        <<~MSG
+        Metanorma has detected that you do not have the necessary fonts installed
+        for PDF generation. The generated PDF will use generic fonts that may not
+        resemble the desired styling. Metanorma can download these files for you
+        if you accept the font licensing conditions for the font #{font_name}.
+
+        If you want Metanorma to download these fonts for you and indicate your
+        acceptance of the font licenses, type "Yes" / "No":
+        MSG
+      end
+    end
+  end
+end

--- a/lib/metanorma/cli/ui.rb
+++ b/lib/metanorma/cli/ui.rb
@@ -3,8 +3,8 @@ require "thor"
 module Metanorma
   module Cli
     class UI < Thor
-      def self.ask(message)
-        new.ask(message)
+      def self.ask(message, options = {})
+        new.ask(message, options)
       end
 
       def self.say(message)

--- a/metanorma-cli.gemspec
+++ b/metanorma-cli.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.4.0'
 
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "byebug", "~> 10.0"
@@ -51,4 +52,5 @@ Gem::Specification.new do |spec|
   #spec.add_runtime_dependency 'nokogiri', ">= 1"
   spec.add_runtime_dependency "git", "~> 1.5"
   spec.add_runtime_dependency "relaton-cli", ">= 0.8.2"
+  spec.add_runtime_dependency "fontist", "~> 0.2.0"
 end

--- a/spec/acceptance/setup_spec.rb
+++ b/spec/acceptance/setup_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+RSpec.describe "Metanorma" do
+  describe "setup" do
+    context "without existing fonts" do
+      it "downlaods user's fonts as specified" do
+        stub_system_home_directory
+        command = %w(setup --agree-to-terms)
+        Metanorma::Cli.start(command)
+
+        expect(installed_fonts.count).to be >= required_fonts.count
+        expect(installed_fonts.grep(/#{required_fonts.first}/i)).not_to be_empty
+      end
+    end
+  end
+
+  def required_fonts
+    Metanorma::Cli::REQUIRED_FONTS
+  end
+
+  def installed_fonts
+    Metanorma::Cli.fonts
+  end
+end

--- a/spec/metanorma/cli/setup_spec.rb
+++ b/spec/metanorma/cli/setup_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe Metanorma::Cli::Setup do
+  describe ".run" do
+    context "with existing fonts" do
+      it "copy overs the existing fonts" do
+        font_name = "Consola.ttf"
+        stub_system_home_directory
+
+        Metanorma::Cli::Setup.run(font: font_name)
+
+        expect(Metanorma::Cli.fonts.grep(/#{font_name}/i)).not_to be_nil
+      end
+    end
+
+    context "with downloadale font" do
+      it "downloads and copy over the font" do
+        stub_system_home_directory
+        font_name = "CALIBRI.TTF"
+        Metanorma::Cli::Setup.run(font: "CALIBRI.TTF")
+
+        expect(Metanorma::Cli.fonts.grep(/#{font_name}/i)).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/support/metanorma_helper.rb
+++ b/spec/support/metanorma_helper.rb
@@ -1,7 +1,8 @@
 module Metanorma
   module Helper
     def stub_system_home_directory
-      allow(Dir).to receive(:home).and_return(Metanorma::Cli.root_path.join("tmp"))
+      allow(Dir).to receive(:home).
+        and_return(Metanorma::Cli.root_path.join("tmp"))
     end
   end
 end


### PR DESCRIPTION
This commit adds a setup interface to the metanorma CLI. This interface should be run to setup all required dependencies. For now we plugging in the fonts installation process.

This is still very early, and very simplified but the interface will stay the same and we will make the core functionality more modular in the coming days.