### PR TITLE
Add `--output-dir` functionality

### DIFF
--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -29,6 +29,7 @@ module Metanorma
       option :relaton, aliases: "-R", desc: "Export Relaton XML for document to nominated filename"
       option :extract, aliases: "-e", desc: "Export sourcecode fragments from this document to nominated directory"
       option :version, aliases: "-v", desc: "Print version of code (accompanied with -t)"
+      option "output-dir", aliases: "-o", desc: "Directory to save compiled files"
 
       def compile(file_name = nil)
         if file_name && !options[:version]

--- a/spec/metanorma/cli/compiler_spec.rb
+++ b/spec/metanorma/cli/compiler_spec.rb
@@ -14,16 +14,30 @@ RSpec.describe Metanorma::Cli::Compiler do
     end
 
     # @TODO: What exactly are we testing here?
+    # The script should exit with non zero status when errors lake following occur:
+    #   [metanorma] Error: xmlrfc2 format is not supported for this standard.
+    #   [metanorma] Error: nits format is not supported for this standard.
+    # See issue 151.
     #
     it "compile with errors" do
-      skip "seems like it's breaking the test suite"
+      # skip "seems like it's breaking the test suite"
+      # Try to update metanorma gem
 
       expect do
         Metanorma::Cli.start(["spec/fixtures/draft-gold-acvp-sub-kdf135-x942.adoc"])
       end.to raise_error SystemExit
 
       delete_file_if_exist("draft-gold-acvp-sub-kdf135-x942.err")
-      delete_file_if_exist("/draft-gold-acvp-sub-kdf135-x942.rfc.xml")
+      delete_file_if_exist("draft-gold-acvp-sub-kdf135-x942.rfc.xml")
+      delete_file_if_exist("draft-gold-acvp-sub-kdf135-x942.")
+    end
+
+    it "write files to specified output dir" do
+      Metanorma::Cli.start(["spec/fixtures/sample-file.adoc", "-o", "spec/assets"])
+      expect(File.exist?("spec/assets/sample-file.html")).to be true
+      expect(File.exist?("spec/assets/sample-file.xml")).to be true
+      expect(File.exist?("spec/assets/sample-file.presentation.xml")).to be true
+      Dir["spec/assets/sample-file.*"].each { |f| File.delete f }
     end
   end
 


### PR DESCRIPTION
Tests fail because of not releasing changes in the metanorma.