### PR TITLE
Adopt changes for fontists license

### DIFF
--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -88,12 +88,12 @@ module Metanorma
             )
           rescue Fontist::Errors::LicensingError
             UI.error(
-              "[error]: Required font license missing! You can accept required" \
-              "licenses using `metanorma setup --agree-to-terms`"
+              "[error]: License acceptance required to install a necessary font." \
+              "Accept required licenses with: `metanorma setup --agree-to-terms`."
             )
             return
           rescue Fontist::Errors::NonSupportedFontError
-            UI.say("[info]: Font `#{font}` is not supported yet!")
+            UI.say("[info]: The font `#{font}` is not yet supported.")
           end
         end
       end

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -86,6 +86,12 @@ module Metanorma
               font: font,
               term_agreement: options[:agree_to_terms],
             )
+          rescue Fontist::Errors::LicensingError
+            UI.error(
+              "[error]: Required font license missing! You can accept required" \
+              "licenses using `metanorma setup --agree-to-terms`"
+            )
+            return
           rescue Fontist::Errors::NonSupportedFontError
             UI.say("[info]: Font `#{font}` is not supported yet!")
           end

--- a/lib/metanorma/cli/setup.rb
+++ b/lib/metanorma/cli/setup.rb
@@ -43,7 +43,7 @@ module Metanorma
         begin
           Fontist::Font.find(font_name)
         rescue Fontist::Errors::MissingFontError
-          ask_user_and_download_font(font_name)
+          process_font_installation(font_name)
         end
       end
 
@@ -54,39 +54,18 @@ module Metanorma
         end
       end
 
-      def ask_user_and_download_font(font_name)
-        response = term_agreement ? "yes" : "no"
-        formula = Fontist::Formula.find(font_name)
+      def process_font_installation(font_name)
+        accepted_agreement = term_agreement == true ? "yes" : "no"
 
-        if !term_agreement
-          response = UI.ask(message(formula.license).strip)
-        end
-
-        if response.downcase === "yes"
-          Fontist::Font.install(font_name, confirmation: response)
-        end
+        UI.say(missing_font_message) if !term_agreement
+        Fontist::Font.install(font_name, confirmation: accepted_agreement)
       end
 
-      def message(license)
+      def missing_font_message
         <<~MSG
-          FONT LICENSE ACCEPTANCE REQUIRED:
-
           Metanorma has detected that you do not have the necessary fonts installed
           for PDF generation. Without those fonts, the generated PDF will use
-          generic fonts that may not resemble the desired styling.
-
-          Metanorma can download these files for you if you accept the font
-          licensing conditions for the font "#{font_name}".
-
-          FONT LICENSE BEGIN ("#{font_name}")
-          -----------------------------------------------------------------------
-          #{license}
-          -----------------------------------------------------------------------
-          FONT LICENSE END ("#{font_name}")
-
-          Do you accept all presented font licenses, and want Metanorma to
-          download these fonts for you?
-          => TYPE "Yes" or "No":
+          generic fonts that may not resemble the desired styling.\n
         MSG
       end
     end

--- a/lib/metanorma/cli/setup.rb
+++ b/lib/metanorma/cli/setup.rb
@@ -63,8 +63,8 @@ module Metanorma
 
       def missing_font_message
         <<~MSG
-          Metanorma has detected that you do not have the necessary fonts installed
-          for PDF generation. Without those fonts, the generated PDF will use
+          Your system does not have the necessary fonts installed for
+          PDF generation. Without these fonts, the generated PDF will use
           generic fonts that may not resemble the desired styling.\n
         MSG
       end

--- a/metanorma-cli.gemspec
+++ b/metanorma-cli.gemspec
@@ -59,5 +59,5 @@ Gem::Specification.new do |spec|
   #spec.add_runtime_dependency 'nokogiri', ">= 1"
   spec.add_runtime_dependency "git", "~> 1.5"
   spec.add_runtime_dependency "relaton-cli", ">= 0.8.2"
-  spec.add_runtime_dependency "fontist", "~> 1.2"
+  spec.add_runtime_dependency "fontist", "~> 1.3.0"
 end

--- a/spec/metanorma/cli/setup_spec.rb
+++ b/spec/metanorma/cli/setup_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Metanorma::Cli::Setup do
         font_name = "FakeCalibri"
 
         stub_system_home_directory
-
         allow(Fontist::Font).to receive(:install).and_return(fixture_fonts)
+
         Metanorma::Cli::Setup.run(font: "CALIBRI.TTF", term_agreement: true)
 
         expect(Metanorma::Cli.fonts.grep(/#{font_name}/i)).not_to be_nil


### PR DESCRIPTION
Now that fontist handles all licenses itself so we don't need to do anything here apart from displaying the missing font message.

This commit adds the necessary changes here to adopt these new changes and also adds gracefully handles missing fonts error.

Related https://github.com/fontist/fontist/issues/116
Closes: #166 