### PR TITLE
Add an interface to generate a mini site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /test
 /testrelaton.xml
 /extract/
+/site/
 
 # rspec failure tracking
 .rspec_status

--- a/README.adoc
+++ b/README.adoc
@@ -285,6 +285,21 @@ repository.
 metanorma template-repo add my-iso https://github.com/you/my-iso-template
 ----
 
+=== Generate metanorma minisite
+
+The `site` interface allows you to manage mini site generation using the CLI.
+To generate a mini site you need to provide the `SOURCE_PATH` and the CLI will
+take care of compiling each of those files and generate deployable site in the
+provided output directory.
+
+This interface also supports a YAML manifest file that can be used to customize
+the site generation process. You can check more details here: link:./spec/fixtures/metanorma.yml[metanorma.yml]
+
+[source, sh]
+----
+metanorma site generate SOURCE_PATH -o OUTPUT_PATH -c metanorma.yml
+----
+
 == Credits
 
 This gem is developed, maintained and funded by https://www.metanorma.com/docs/getting-started/[Ribose Inc.]

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -3,6 +3,7 @@ require "metanorma/cli/compiler"
 require "metanorma/cli/generator"
 require "metanorma/cli/git_template"
 require "metanorma/cli/commands/template_repo"
+require "metanorma/cli/commands/site"
 require "metanorma"
 
 module Metanorma
@@ -91,6 +92,9 @@ module Metanorma
 
       desc "template-repo", "Manage metanorma templates repository"
       subcommand :template_repo, Metanorma::Cli::Commands::TemplateRepo
+
+      desc "site", "Manage site for metanorma collections"
+      subcommand :site, Metanorma::Cli::Commands::Site
 
       private
 

--- a/lib/metanorma/cli/commands/site.rb
+++ b/lib/metanorma/cli/commands/site.rb
@@ -10,7 +10,7 @@ module Metanorma
         option(
           :output_dir,
           aliases: "-o",
-          default: Pathname.new(Dir.pwd).join("site"),
+          default: Pathname.new(Dir.pwd).join("site").to_s,
           desc: "Output directory for the generated site",
         )
 

--- a/lib/metanorma/cli/commands/site.rb
+++ b/lib/metanorma/cli/commands/site.rb
@@ -1,0 +1,26 @@
+require "pathname"
+require "metanorma/cli/site_generator"
+
+module Metanorma
+  module Cli
+    module Commands
+      class Site < Thor
+        desc "site generate SOURCE_PATH", "Geneate site from collection"
+        option :config, aliases: "-c", desc: "The metanorma configuration file"
+        option(
+          :output_dir,
+          aliases: "-o",
+          default: Pathname.new(Dir.pwd).join("site"),
+          desc: "Output directory for the generated site",
+        )
+
+        def generate(source_path)
+          Cli::SiteGenerator.generate(source_path, options.dup)
+          UI.say("Site has been generated at #{options[:output_dir]}")
+        rescue Cli::Errors::InvalidManifestFileError
+          UI.error("Invalid data in: #{options[:config]}")
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/cli/errors.rb
+++ b/lib/metanorma/cli/errors.rb
@@ -4,6 +4,7 @@ module Metanorma
       class DuplicateTemplateError < StandardError; end
 
       class FileNotFoundError < StandardError; end
+      class InvalidManifestFileError < StandardError; end
     end
   end
 end

--- a/lib/metanorma/cli/site_generator.rb
+++ b/lib/metanorma/cli/site_generator.rb
@@ -1,0 +1,128 @@
+require "yaml"
+require "pathname"
+require "fileutils"
+
+module Metanorma
+  module Cli
+    class SiteGenerator
+      def initialize(source, options = {})
+        @source = find_realpath(source)
+        @site_path = options.fetch(:output_dir, "site").to_s
+        @manifest_file = find_realpath(options.fetch(:config, nil))
+        @asset_folder = options.fetch(:asset_folder, "documents").to_s
+        @collection_name = options.fetch(:collection_name, "documents.xml")
+
+        ensure_site_asset_directory!
+      end
+
+      def self.generate(source, options = {})
+        new(source, options).generate
+      end
+
+      def generate
+        site_directory = asset_directory.join("..")
+
+        Dir.chdir(site_directory) do
+          select_source_files.each { |source| compile(source) }
+
+          build_collection_file(collection_name)
+          convert_to_html_page(collection_name, "index.html")
+        end
+      end
+
+      private
+
+      attr_reader :source, :asset_folder, :asset_directory
+      attr_reader :site_path, :manifest_file, :collection_name
+
+      def find_realpath(source_path)
+        Pathname.new(source_path.to_s).realpath if source_path
+      rescue Errno::ENOENT
+        source_path
+      end
+
+      def select_source_files
+        files = source_from_manifest
+
+        if files.empty?
+          files = Dir[File.join(source, "**", "*.adoc")]
+        end
+
+        files.flatten.uniq.reject { |file| File.directory?(file) }
+      end
+
+      def build_collection_file(collection_name)
+        UI.info("Building collection file ...")
+
+        Relaton::Cli::RelatonFile.concatenate(
+          asset_folder,
+          collection_name,
+          title: manifest[:collection_name],
+          organization: manifest[:collection_organization],
+        )
+      end
+
+      def compile(source)
+        UI.info("Compiling #{source} ...")
+
+        Metanorma::Cli::Compiler.compile(
+          source.to_s, format: :asciidoc, "output-dir" => asset_folder
+        )
+      end
+
+      def convert_to_html_page(collection, page_name)
+        UI.info("Generating html site ...")
+
+        Relaton::Cli::XMLConvertor.to_html(collection)
+        File.rename(Pathname.new(collection).sub_ext(".html").to_s, page_name)
+      end
+
+      def manifest
+        @manifest ||= config_from_manifest || {
+          files: [], collection_name: "", collection_organization: ""
+        }
+      end
+
+      def config_from_manifest
+        if manifest_file
+          manifest_config(YAML.safe_load(File.read(manifest_file.to_s)))
+        end
+      end
+
+      def manifest_config(manifest)
+        {
+          files: extract_config_data(
+            manifest["metanorma"]["source"], "files"
+          ) || [],
+
+          collection_name: extract_config_data(
+            manifest["relaton"]["collection"], "name"
+          ),
+
+          collection_organization: extract_config_data(
+            manifest["relaton"]["collection"], "organization"
+          ),
+        }
+      rescue NoMethodError
+        raise Errors::InvalidManifestFileError.new("Invalid manifest file")
+      end
+
+      def extract_config_data(node, key)
+        node ? node[key] : nil
+      end
+
+      def source_from_manifest
+        @source_from_manifest ||= manifest[:files].map do |source|
+          manifest_file.dirname.join(source)
+        end
+      end
+
+      def ensure_site_asset_directory!
+        asset_path = [site_path, asset_folder].join("/")
+        @asset_directory = Pathname.new(Dir.pwd).join(asset_path)
+
+        FileUtils.mkdir_p(@asset_directory) unless @asset_directory.exist?
+      end
+    end
+  end
+end

--- a/lib/metanorma/cli/site_generator.rb
+++ b/lib/metanorma/cli/site_generator.rb
@@ -52,7 +52,8 @@ module Metanorma
       end
 
       def build_collection_file(collection_name)
-        UI.info("Building collection file ...")
+        collection_path = [site_path, collection_name].join("/")
+        UI.info("Building collection file: #{collection_path} ...")
 
         Relaton::Cli::RelatonFile.concatenate(
           asset_folder,
@@ -71,7 +72,7 @@ module Metanorma
       end
 
       def convert_to_html_page(collection, page_name)
-        UI.info("Generating html site ...")
+        UI.info("Generating html site in #{site_path} ...")
 
         Relaton::Cli::XMLConvertor.to_html(collection)
         File.rename(Pathname.new(collection).sub_ext(".html").to_s, page_name)
@@ -112,8 +113,8 @@ module Metanorma
       end
 
       def source_from_manifest
-        @source_from_manifest ||= manifest[:files].map do |source|
-          manifest_file.dirname.join(source)
+        @source_from_manifest ||= manifest[:files].map do |source_file|
+          source.join(source_file)
         end
       end
 

--- a/lib/metanorma/cli/ui.rb
+++ b/lib/metanorma/cli/ui.rb
@@ -11,6 +11,10 @@ module Metanorma
         new.say(message)
       end
 
+      def self.info(message)
+        new.say(["[info]", message].join(": "))
+      end
+
       def self.error(message)
         new.error(message)
       end

--- a/spec/acceptance/generate_site_spec.rb
+++ b/spec/acceptance/generate_site_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.describe "Metanorma" do
+  describe "site generate" do
+    it "generate a mini site" do
+      output_dir = source_dir.join("site").to_s
+      allow(Metanorma::Cli::SiteGenerator).to receive(:generate)
+      command = %W(site generate #{source_dir} -o #{output_dir})
+
+      output = capture_stdout { Metanorma::Cli.start(command) }
+
+      expect(output).to include("Site has been generated at #{output_dir}")
+      expect(Metanorma::Cli::SiteGenerator).to have_received(:generate).with(
+        source_dir.to_s, output_dir: output_dir
+      )
+    end
+  end
+
+  def source_dir
+    @source_dir ||= Metanorma::Cli.root_path.join("tmp")
+  end
+end

--- a/spec/fixtures/metanorma.yml
+++ b/spec/fixtures/metanorma.yml
@@ -1,0 +1,32 @@
+---
+# Optional: Metanora Node
+#
+# The metanorma ndoe allows us to customize the metanorma
+# complilation process, as of now we are supporting to be
+# selectetive about which file to use, but in future we
+# might add more functionality thourgh it.
+#
+metanorma:
+
+  # Optional: Source files
+  #
+  # The following source node can be used to be selective about
+  # the files in the specified source directory. The way you add
+  # files here is to use relative path in regards to source path
+  #
+  source:
+    files:
+      - ./sample.adoc
+      - ./sample.adoc
+      - ./sample-itu.adoc
+
+# Required: Site metadata
+#
+# The following relaton node is required for site generation.
+# The collection node data are used in the site title or heading
+# and the organization is used in the copyright area.
+#
+relaton:
+  collection:
+    organization: "Metanorma : Organization name sample"
+    name: "Metanorma: Sample collection name from metanorma.yml"

--- a/spec/fixtures/metanorma.yml
+++ b/spec/fixtures/metanorma.yml
@@ -12,7 +12,8 @@ metanorma:
   #
   # The following source node can be used to be selective about
   # the files in the specified source directory. The way you add
-  # files here is to use relative path in regards to source path
+  # files here is to use relative paths in regards to source path
+  # not necessarily related to the configuration file path.
   #
   source:
     files:

--- a/spec/fixtures/sample-itu.adoc
+++ b/spec/fixtures/sample-itu.adoc
@@ -1,0 +1,109 @@
+= Telecommunication for rural and remote areas
+:bureau: D
+:docnumber: D.19
+:published-date: 2019-01
+:status: in-force
+:doctype: recommendation
+:imagesdir: images
+:docfile: D-REC-D.19-201003-E.adoc
+:mn-document-class: itu
+:mn-output-extensions: xml,html,doc,pdf,rxl
+:local-cache-only:
+:data-uri-image:
+:section-refsig: Clause
+:xrefstyle: short
+:legacy-do-not-insert-missing-sections:
+
+== {blank}
+
+ITU-D
+
+_recognizing_
+
+. that the following Recommendations resulting from the ITU-D study periods 1998-2002 and 2002-2006 have provided guidance on a number of issues concerning telecommunications/ICTs in rural and remote areas:
+
+** RECOMMENDATION ITU-D 6-1, Appropriate low-cost technology options for the provision of telecommunications in rural and remote areas, (January, 2002);
+
+** RECOMMENDATION ITU-D 7-1, Planning and implementation of national telecommunication development plans for rural and remote areas, (January, 2002)
+
+** RECOMMENDATION ITU-D 8-1, Promotion of the application of telecommunication facilities for developing various sectors in rural and remote areas; (January, 2002);
+
+** RECOMMENDATION ITU-D 9-1, Appropriate regulatory structures as a means of encouraging the extension of telecommunication services to remote and rural areas, (January, 2002);
+
+** RECOMMENDATION ITU-D 10-1, Options available for financing rural and remote telecommunication programmes and projects, (January, 2002);
+
+** RECOMMENDATION ITU-D 17, Sharing of facilities in rural and remote areas (January, 2002);
+
+** RECOMMENDATION ITU D 18, Potential benefits of rural telecommunications (March, 2006).
+
+
+. that the Focus Group 7 addressed technological options, service potential and financing mechanisms for the provision of telecommunications/ICTs in rural and remote areas;
+
+
+_noting_
+
+. that Focus Group 7 on Rural Telecommunications has paid particular attention to the role of Micro-Finance Institutions (MFI) in promoting access to ICT services and application by supporting small entrepreneurs
+
+. the excellent results of the study period 2006-2010 which consolidate experiences world-wide on the successful provision of telecommunications/ICTs to rural and remote areas, based, inter alia, on information submitted to the case library and on e-Discussions on the issues identified by the Rapporteur Group; {blank}footnote:[The case library on Question 10-2/2 is available at
+http://www.itu.int/ITU-D/study_groups/SGP_2006-2010/events/Case_Library/index.asp.
+e-Discussion web page is available at http://www.itu.int/ituweblogs/ITU-D-SG2-Q10/]
+
+. that experiences all over the world, with emerging technologies deployed in rural and remote areas providing broadband, wired transmission media and wireless transmission media indicate rapid decrease of costs, increase of range and capacity, and that all these developments make connecting rural areas a feasible option;
+
+. that satellite technologies, including satellite backhaul solutions, play a unique role in extending service delivery and coverage areas and Very Small Aperture Terminals (VSAT) technology has established itself as a versatile communication platform for rural and remote areas;
+
+. that the deployment of IP based platforms serving wide areas can make a range of developmental services and applications such as education, health, agriculture etc., available to the rural population;
+
+. that these developments make it possible that telecommunication/ICT services and applications can be provided by small and medium enterprises, local governments, non-governmental organizations in rural and remote areas with appropriate business models;
+
+. that technical expertise and adoption capacity are important factors to plan, implement and operate such facilities;
+
+. that in rural and remote areas of developing countries, low incomes, lack of literacy and computer literacy limit the number of people who can have internet access in their homes. These communities need public ICT facilities which can be used for communication, delivery of services and various capacity building activities. There is a role for small entrepreneurs, local governments, schools and post offices in this process;
+
+. that provision of ICT services and applications by small entrepreneurs in rural and remote areas have the potential of creating employment. These ventures can be supported by financial institutions and receive support from various government schemes;
+
+. that a well planned maintenance and operation programme in order to keep the infrastructure and associated equipment, including terminal equipment in good working condition is an essential aspect of the support structures in rural areas;
+
+. the excellent collaboration between ITU/BDT and the Universal Postal Union in promoting the use of post offices as vehicles for provision of access to telecommunications/ICT services and applications in rural and remote areas;
+
+. that energy supply is a basic bottleneck for the spread of telecommunications/ICTs in rural and remote areas and that innovative uses of solar power, mini-hydro power and windmill power sources, some times in combination are being successfully used in many countries to provide reliable energy sources for mobile base stations;
+
+
+
+_considering_
+
+. that the provision of telecommunications, ICT services and applications can make significant contribution to the quality of life of the population living rural and remote areas;
+
+. that stimulation of demand for telecommunications/ICTs through proactive government policies is a key to realizing their benefits;
+
+. that the accumulation of experiences world-wide on community access institutions (telekiosks, multipurpose community telecentres, multi-media centres), points to the need for pro-active and supportive government policies to simulate demand of the services available;
+
+. that the availability of information should be reinforced by upgradation of skills and provision of capital in order that information is properly utilized; and
+
+. that access to telecommunications/ICTs for all will maximize social welfare, increase productivity, conserve resources and will contribute to safeguarding human rights.
+
+
+
+_recommends_
+
+. that developing countries should include provision of telecommunications/ICTs in rural and remote areas in their national development plans;
+
+. that in planning infrastructure development in rural and remote areas it is important to assess all available technologies in the market taking into consideration the regulatory environment, geographical conditions, climate, costs (capital expenditure and operational expenditure), maintainability, operability, sustainability, etc., based on the results of the site survey;
+
+. that community access to ICT facilities and services is particularly important in rural and remote areas. Business models which can achieve financial and operational sustainability can be operated by local entrepreneurs supported by a variety of initiatives. These facilities, where necessary, should also be supported by Universal Service Funds as an essential component of rural communications;
+
+. that post offices have a communicative presence in the lives of the population in rural areas and their use as vehicles for provision of telecommunication/ICTs should be encouraged;
+
+. that local institutions, such as village committees should be involved in planning and implementing ICT facilities;
+
+. that enhancing local technical expertise and adoption are important for successful implementation of ICT services and applications in rural and remote areas. Attention should be paid to training, exchange of information, creation of shared maintenance facilities in order to achieve sustainability and viability;
+
+. that migration to broadband technology should be encouraged;
+
+. that keeping even technologically obsolete equipment in good working condition through effective preventive maintenance programme is an essential part of making telecommunications in rural areas viable and should be encouraged, while guarding against making developing countries a dumping ground for obsolete technologies;
+
+. that it is important to take steps to ensure continued reliability of equipment in rural environments such as developing an appropriate maintenance and operation strategy and encouraging training for technical staff;
+
+. that given that lack of energy supply is a major bottleneck in the provision of telecommunications/ICTs in rural and remote areas, renewable energy sources should be used whenever feasible taking into consideration the environmental problems; and
+
+. that partnership among governments, industry, local agencies and international organizations is desirable in the development of low cost ICT infrastructure, including renewable energy sources and terminals for the provision of telecommunications/ICTs in rural and remote areas and should be pursued.

--- a/spec/metanorma/cli/site_generator_spec.rb
+++ b/spec/metanorma/cli/site_generator_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Metanorma::Cli::SiteGenerator do
         stub_external_interface_calls
 
         Metanorma::Cli::SiteGenerator.generate(
-          source_path.join("invalid"),
+          source_path,
           output_dir: output_directory,
           config: source_path.join("metanorma.yml"),
         )

--- a/spec/metanorma/cli/site_generator_spec.rb
+++ b/spec/metanorma/cli/site_generator_spec.rb
@@ -1,0 +1,97 @@
+require "spec_helper"
+
+RSpec.describe Metanorma::Cli::SiteGenerator do
+  describe ".generate" do
+    context "without  manifest file" do
+      it "invokes sets of messages to generate a complete site" do
+        asset_folder = "documents"
+        stub_external_interface_calls
+
+        Metanorma::Cli::SiteGenerator.generate(
+          source_path, output_dir: output_directory
+        )
+
+        expect(Metanorma::Cli::Compiler).to have_received(:compile).with(
+          sources.first.to_s, format: :asciidoc, "output-dir" => asset_folder
+        )
+
+        expect(Relaton::Cli::RelatonFile).to have_received(:concatenate).with(
+          asset_folder, "documents.xml", title: "", organization: ""
+        )
+      end
+
+      it "converts the collection xml to html and reanmes it to index" do
+        stub_external_interface_calls
+        collection_xml = "documents.xml"
+
+        Metanorma::Cli::SiteGenerator.generate(
+          source_path, output_dir: output_directory
+        )
+
+        expect(File).to have_received(:rename).with(
+          Pathname.new(collection_xml).sub_ext(".html").to_s, "index.html"
+        )
+
+        expect(Relaton::Cli::XMLConvertor).to have_received(:to_html).with(
+          collection_xml,
+        )
+      end
+    end
+
+    context "with manifest file" do
+      it "usages the manifest to select files and passes it to relaton" do
+        asset_folder = "documents"
+        stub_external_interface_calls
+
+        Metanorma::Cli::SiteGenerator.generate(
+          source_path.join("invalid"),
+          output_dir: output_directory,
+          config: source_path.join("metanorma.yml"),
+        )
+
+        collection = manifest["relaton"]["collection"]
+        manifest_files = manifest["metanorma"]["source"]["files"]
+
+        manifest_files.each do |manifest_file|
+          expect(Metanorma::Cli::Compiler).to have_received(:compile).with(
+            source_path.join(manifest_file).to_s,
+            format: :asciidoc,
+            "output-dir" => asset_folder,
+          )
+        end
+
+        expect(Metanorma::Cli::Compiler).to have_received(:compile).twice
+
+        expect(Relaton::Cli::RelatonFile).to have_received(:concatenate).with(
+          asset_folder,
+          "documents.xml",
+          title: collection["name"],
+          organization: collection["organization"],
+        )
+      end
+    end
+
+    def stub_external_interface_calls
+      allow(File).to receive(:rename)
+      allow(Metanorma::Cli::Compiler).to receive(:compile)
+      allow(Relaton::Cli::XMLConvertor).to receive(:to_html)
+      allow(Relaton::Cli::RelatonFile).to receive(:concatenate)
+    end
+
+    def sources
+      @sources ||= Dir[File.join(source_path.to_s, "**", "*.adoc")]
+    end
+
+    def output_directory
+      @output_directory ||= Metanorma::Cli.root_path.join("tmp")
+    end
+
+    def source_path
+      @source_path ||= Metanorma::Cli.root_path.join("spec", "fixtures")
+    end
+
+    def manifest
+      @manifest ||= YAML.safe_load(File.read(source_path.join("metanorma.yml")))
+    end
+  end
+end


### PR DESCRIPTION
Site generation is another task that we want to handle through the Metanorma CLI. The way it should work is: we would pass a source directory and we want metanorma to find each of the files and run the compiler to compile those to an expected output.

Once the complication is done then we also want it to invoke the Relaton library to build the collection and finally convert the
collection to a base HTML page.

We also wanted this interface to support a configuration file, so each site generation will also have more control over the
internal of site generation. This is exactly what this commit tried to achieve, so now a user can generate a mini-site using

```sh
./exe/metanorma site generate SOURCE_PATH -o OUTPUT_PATH -c manifest.yml
```

Fixes: #130 