### PR TITLE
Add support for wildcards in file selection

### DIFF
--- a/lib/metanorma/cli/site_generator.rb
+++ b/lib/metanorma/cli/site_generator.rb
@@ -114,8 +114,9 @@ module Metanorma
 
       def source_from_manifest
         @source_from_manifest ||= manifest[:files].map do |source_file|
-          source.join(source_file)
-        end
+          file_path = source.join(source_file).to_s
+          file_path.include?("*") ? Dir.glob(file_path) : file_path
+        end.flatten
       end
 
       def ensure_site_asset_directory!

--- a/spec/fixtures/metanorma.yml
+++ b/spec/fixtures/metanorma.yml
@@ -13,10 +13,15 @@ metanorma:
   # The following source node can be used to be selective about
   # the files in the specified source directory. The way you add
   # files here is to use relative paths in regards to source path
-  # not necessarily related to the configuration file path.
+  # not necessarily related to the configuration file path. The
+  # file selections also support wildcards.
+  #
+  # The following are examples of supported pattern, the CLI is
+  # also smart ignore any duplicates automaticaly.
   #
   source:
     files:
+      - ./*.adoc
       - ./sample.adoc
       - ./sample.adoc
       - ./sample-itu.adoc

--- a/spec/metanorma/cli/site_generator_spec.rb
+++ b/spec/metanorma/cli/site_generator_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe Metanorma::Cli::SiteGenerator do
         )
 
         collection = manifest["relaton"]["collection"]
-        manifest_files = manifest["metanorma"]["source"]["files"]
+        manifest_files = select_files_including_wildcard(
+          manifest["metanorma"]["source"]["files"],
+        )
 
         manifest_files.each do |manifest_file|
           expect(Metanorma::Cli::Compiler).to have_received(:compile).with(
@@ -60,7 +62,9 @@ RSpec.describe Metanorma::Cli::SiteGenerator do
           )
         end
 
-        expect(Metanorma::Cli::Compiler).to have_received(:compile).twice
+        expect(Metanorma::Cli::Compiler).to have_received(:compile).exactly(
+          manifest_files.uniq.count,
+        ).times
 
         expect(Relaton::Cli::RelatonFile).to have_received(:concatenate).with(
           asset_folder,
@@ -84,6 +88,13 @@ RSpec.describe Metanorma::Cli::SiteGenerator do
 
     def output_directory
       @output_directory ||= Metanorma::Cli.root_path.join("tmp")
+    end
+
+    def select_files_including_wildcard(files)
+      files.map do |file|
+        file_path = source_path.join(file).to_s
+        file_path.to_s.include?("*") ? Dir.glob(file_path) : file_path
+      end.flatten
     end
 
     def source_path


### PR DESCRIPTION
The earlier version of the mini-site configuration file only supports a list with exact filenames, but we want this to support wildcard so we don't have to specify every single file.

This commit adds the support for this wild card pattern, and it also ensures we handle the duplicates gracefully.

Related #192