### PR TITLE
Fix site command related help documentations

### DIFF
--- a/lib/metanorma/cli/commands/site.rb
+++ b/lib/metanorma/cli/commands/site.rb
@@ -5,7 +5,7 @@ module Metanorma
   module Cli
     module Commands
       class Site < Thor
-        desc "site generate SOURCE_PATH", "Geneate site from collection"
+        desc "generate SOURCE_PATH", "Geneate site from collection"
         option :config, aliases: "-c", desc: "The metanorma configuration file"
         option(
           :output_dir,


### PR DESCRIPTION
There seems to be a minor issue with the help documentation for the site generation command which might be a bit confusing. This commit fixes it so running `metanorma site --help` should work as expected.