### PR TITLE
Fix include related compilation issues

### DIFF
--- a/lib/metanorma/cli/site_generator.rb
+++ b/lib/metanorma/cli/site_generator.rb
@@ -21,10 +21,9 @@ module Metanorma
 
       def generate
         site_directory = asset_directory.join("..")
+        select_source_files.each { |source| compile(source) }
 
         Dir.chdir(site_directory) do
-          select_source_files.each { |source| compile(source) }
-
           build_collection_file(collection_name)
           convert_to_html_page(collection_name, "index.html")
         end
@@ -67,7 +66,7 @@ module Metanorma
         UI.info("Compiling #{source} ...")
 
         Metanorma::Cli::Compiler.compile(
-          source.to_s, format: :asciidoc, "output-dir" => asset_folder
+          source.to_s, format: :asciidoc, "output-dir" => asset_directory
         )
       end
 

--- a/spec/metanorma/cli/site_generator_spec.rb
+++ b/spec/metanorma/cli/site_generator_spec.rb
@@ -6,13 +6,14 @@ RSpec.describe Metanorma::Cli::SiteGenerator do
       it "invokes sets of messages to generate a complete site" do
         asset_folder = "documents"
         stub_external_interface_calls
+        asset_directory = output_directory.join(asset_folder)
 
         Metanorma::Cli::SiteGenerator.generate(
           source_path, output_dir: output_directory
         )
 
         expect(Metanorma::Cli::Compiler).to have_received(:compile).with(
-          sources.first.to_s, format: :asciidoc, "output-dir" => asset_folder
+          sources.first.to_s, format: :asciidoc, "output-dir" => asset_directory
         )
 
         expect(Relaton::Cli::RelatonFile).to have_received(:concatenate).with(
@@ -58,7 +59,7 @@ RSpec.describe Metanorma::Cli::SiteGenerator do
           expect(Metanorma::Cli::Compiler).to have_received(:compile).with(
             source_path.join(manifest_file).to_s,
             format: :asciidoc,
-            "output-dir" => asset_folder,
+            "output-dir" => output_directory.join(asset_folder),
           )
         end
 


### PR DESCRIPTION
We are running the compilation and collection building inside from the expected output directory, this is good for isolations during the site generation phase but it was not correctly resolving the file path for the compiler.

This commit fixes this issue by moving out the compile step from that isolation and use an absolute path for compiled output.

One note though, it turns out the `compile` interface is not behaving as expected when you are not in the source directory, and run compile interface for a file that includes include directive. This could be an issue with the interface or how AsciiDoc handles include.

Fixes #196