### PR TITLE
Add support to respect  the default manifest

### DIFF
--- a/lib/metanorma/cli/site_generator.rb
+++ b/lib/metanorma/cli/site_generator.rb
@@ -8,9 +8,9 @@ module Metanorma
       def initialize(source, options = {})
         @source = find_realpath(source)
         @site_path = options.fetch(:output_dir, "site").to_s
-        @manifest_file = find_realpath(options.fetch(:config, nil))
         @asset_folder = options.fetch(:asset_folder, "documents").to_s
         @collection_name = options.fetch(:collection_name, "documents.xml")
+        @manifest_file = find_realpath(options.fetch(:config, default_config))
 
         ensure_site_asset_directory!
       end
@@ -38,6 +38,11 @@ module Metanorma
         Pathname.new(source_path.to_s).realpath if source_path
       rescue Errno::ENOENT
         source_path
+      end
+
+      def default_config
+        default_file = Pathname.new(Dir.pwd).join("metanorma.yml")
+        default_file if File.exist?(default_file)
       end
 
       def select_source_files


### PR DESCRIPTION
During porting the `site` interface to build scripts, I realized all of the samples, and templates repos are using a default config
file called `metanorma.yml`. To comply with this all actions need to pass this file to the site generator which creates some sort of dependency, especially if a repo doesn't have a config file.

This commit changes this, so when no config file is provided then it will also try to find a manifest in the current directory, and
if there is one then it will use that one for site generation.