### PR TITLE
Add support to list out available doctypes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -228,6 +228,32 @@ Options:
   -c, [--coverpage=COVERPAGE]       # Cover page as Liquid template for collection (currently HTML only)
 ----
 
+=== List supported doctypes (`metanorma list-doctypes`)
+
+You want to know what are the supported doctypes and what do they support for
+input and output format? Well, the `metanorma list-doctypes` can help.
+
+
+[source,sh]
+----
+metanorma list-doctypes
+----
+
+
+To list out the details for a specific flavor run the following command:
+
+[source,sh]
+----
+metanorma list-doctypes <flavor>
+----
+
+e.g.,
+
+[source,sh]
+----
+metanorma list-doctypes iso
+----
+
 === List supported output formats (`metanorma list-extensions`)
 
 Need to know what output formats are supported for a given flavor?

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -90,6 +90,17 @@ module Metanorma
         UI.say("Couldn't load #{type}, please provide a valid type!")
       end
 
+      desc "list-doctypes", "List supported doctypes"
+      def list_doctypes(type = nil)
+        processors = backend_processors
+
+        if type && processors[type.to_sym]
+          processors = { type.to_sym => processors[type.to_sym] }
+        end
+
+        print_doctypes_table(processors)
+      end
+
       desc "template-repo", "Manage metanorma templates repository"
       subcommand :template_repo, Metanorma::Cli::Commands::TemplateRepo
 
@@ -122,6 +133,13 @@ module Metanorma
         if type
           UI.say(find_backend(type).version)
         end
+      end
+
+      def backend_processors
+        @backend_processors ||= (
+          Metanorma::Cli.load_flavors
+          Metanorma::Registry.instance.processors
+        )
       end
 
       def find_backend(type)
@@ -159,6 +177,18 @@ module Metanorma
         unless Metanorma::Registry.instance.find_processor(type&.to_sym)
           require "metanorma-#{type}"
         end
+      end
+
+      def print_doctypes_table(processors)
+        table_data = processors.map do |type_sym, processor|
+          [
+            type_sym.to_s,
+            processor.input_format,
+            join_keys(processor.output_formats.keys),
+          ]
+        end
+
+        UI.table(["Type", "Input", "Supported output format"], table_data)
       end
     end
   end

--- a/lib/metanorma/cli/ui.rb
+++ b/lib/metanorma/cli/ui.rb
@@ -19,6 +19,10 @@ module Metanorma
         new.error(message)
       end
 
+      def self.table(header, data)
+        new.print_table(data.unshift(header))
+      end
+
       def self.run(command)
         require "open3"
         Open3.capture3(command)

--- a/spec/acceptance/list_doctypes_spec.rb
+++ b/spec/acceptance/list_doctypes_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe "Metanorma" do
+  describe "list-doctypes" do
+    context "without any type specified" do
+      it "list details for supported doctypes" do
+        command = %w(list-doctypes)
+        output = capture_stdout { Metanorma::Cli.start(command) }
+
+        expect(output).to include("Type     Input     Supported output format")
+        expect(output).to include("standoc  asciidoc  xml, presentation, rxl")
+      end
+    end
+
+    context "with type specified" do
+      it "list out the details for that type" do
+        command = %w(list-doctypes iso)
+        output = capture_stdout { Metanorma::Cli.start(command) }
+
+        expect(output).to include("Type  Input     Supported output format")
+        expect(output).to include("iso   asciidoc  xml, presentation, rxl, html")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the `metanorma list-doctypes` interface that can be used to list out all of the supported flavors, this also prints out supported input and output formats.

By default it will print out all the flavors but you can pass the flavor as an argument then it will only list out that flavor.

```sh
metanorma list-doctypes
```

Output:

<img width="717" alt="Screen Shot 2021-01-01 at 5 17 50 PM" src="https://user-images.githubusercontent.com/1220911/103442313-552ee580-4c55-11eb-951f-54b7a8bef45f.png">


Fixes #59