### PR TITLE
Use ref instead sha

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - run: echo "ref=${GITHUB_REF}"
+
       - name: Trigger repositories
         env:
           GH_USERNAME: metanorma-ci

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -2,17 +2,16 @@
 # See https://github.com/metanorma/cimas
 name: notify
 
-on: status
+on:
+  repository_dispatch:
+    types: [ notify ]
 
 jobs:
   notify:
     name: Notify dependent repos
     runs-on: ubuntu-latest
-    if: github.event.context == 'tests-passed-successfully'
     steps:
-      - uses: actions/checkout@master
-
-      - run: echo "ref=${GITHUB_REF}"
+      - uses: actions/checkout@v2
 
       - name: Trigger repositories
         env:
@@ -22,7 +21,7 @@ jobs:
           curl -LO --retry 3 https://raw.githubusercontent.com/metanorma/metanorma-build-scripts/master/trigger-gh-actions.sh
           [[ -f ".github/workflows/dependent_repos.env" ]] && source .github/workflows/dependent_repos.env
           CLIENT_PAYLOAD=$(cat <<EOF
-          "{ "ref": "${GITHUB_REF}", "repo": "${GITHUB_REPOSITORY}" }"
+          "{ "ref": "${{ github.event.client_payload.ref }}", "repo": "${GITHUB_REPOSITORY}" }"
           EOF
           )
           for repo in $TEMPLATE_REPOS" $SAMPLES_REPOS"
@@ -31,7 +30,7 @@ jobs:
           done
 
       - name: Trigger release repositories
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+        if: github.event.client_payload.ref == 'refs/heads/master' || startsWith(github.event.client_payload.ref, 'refs/tags/v')
         env:
           GH_USERNAME: metanorma-ci
           GH_ACCESS_TOKEN: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
@@ -39,7 +38,7 @@ jobs:
           curl -LO --retry 3 https://raw.githubusercontent.com/metanorma/metanorma-build-scripts/master/trigger-gh-actions.sh
           [[ -f ".github/workflows/dependent_repos.env" ]] && source .github/workflows/dependent_repos.env
           CLIENT_PAYLOAD=$(cat <<EOF
-          "{ "ref": "${GITHUB_REF}", "repo": "${GITHUB_REPOSITORY}" }"
+          "{ "ref": "${{ github.event.client_payload.ref }}", "repo": "${GITHUB_REPOSITORY}" }"
           EOF
           )
           for repo in $DEPENDENT_REPOS

--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -4,7 +4,7 @@ name: rake
 
 on:
   push:
-    branches: [ master, main  ]
+    branches: [ master, main ]
     tags: [ v* ]
   pull_request:
 
@@ -55,11 +55,9 @@ jobs:
     needs: rake
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger tests passed event
-        uses: Sibz/github-status-action@v1
+      - uses: peter-evans/repository-dispatch@v1
         with:
-          authToken: ${{ secrets.METANORMA_CI_PAT_TOKEN || secrets.GITHUB_TOKEN }}
-          context: 'tests-passed-successfully'
-          description: 'Tests passed successfully'
-          state: 'success'
-          sha: ${{ github.event.pull_request.head.ref || github.ref }}
+          token: ${{ secrets.METANORMA_CI_PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          event-type: notify
+          client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -62,4 +62,4 @@ jobs:
           context: 'tests-passed-successfully'
           description: 'Tests passed successfully'
           state: 'success'
-          sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          sha: ${{ github.event.pull_request.head.ref || github.ref }}


### PR DESCRIPTION
After moving to separate notify workflow, ref don't send to dependent repos, just sha