### PR TITLE
Add default source path for site interface

### DIFF
--- a/lib/metanorma/cli/commands/site.rb
+++ b/lib/metanorma/cli/commands/site.rb
@@ -6,7 +6,7 @@ module Metanorma
   module Cli
     module Commands
       class Site < ThorWithConfig
-        desc "generate SOURCE_PATH", "Generate site from collection"
+        desc "generate [SOURCE_PATH]", "Generate site from collection"
         option :config, aliases: "-c", desc: "Metanorma configuration file"
         option(
           :output_dir,
@@ -19,7 +19,7 @@ module Metanorma
         option :no_install_fonts, type: :boolean, desc: "Skip the font installation process"
         option :continue_without_fonts, type: :boolean, desc: "Continue processing even when fonts are missing"
 
-        def generate(source_path)
+        def generate(source_path = Dir.pwd)
           Cli::SiteGenerator.generate(source_path, options, filter_compile_options(options))
           UI.say("Site has been generated at #{options[:output_dir]}")
         rescue Cli::Errors::InvalidManifestFileError

--- a/spec/acceptance/generate_site_spec.rb
+++ b/spec/acceptance/generate_site_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe "Metanorma" do
         continue_without_fonts: true
       )
     end
+
+    it "usages pwd as default source path" do
+      allow(Metanorma::Cli::SiteGenerator).to receive(:generate)
+      command = %w(site generate)
+      capture_stdout { Metanorma::Cli.start(command) }
+
+      expect(Metanorma::Cli::SiteGenerator).to have_received(:generate).with(
+        Dir.pwd.to_s, any_args
+      )
+    end
   end
 
   def source_dir


### PR DESCRIPTION
The current site interface expect us to pass a specific path, but this might feel redundant especially when we are already in the present working directory and we still have to pass `.` just to meet that requirement.

This commit changes this, and makes the `source_path` optional, so now user doesn't need to provide `.` for present working directory.

Fixes #208