### PR TITLE
Add support for custom template in site

### DIFF
--- a/lib/metanorma/cli/commands/site.rb
+++ b/lib/metanorma/cli/commands/site.rb
@@ -18,6 +18,8 @@ module Metanorma
                                                       "presented (WARNING: do know what you are agreeing with!)"
         option :no_install_fonts, type: :boolean, desc: "Skip the font installation process"
         option :continue_without_fonts, type: :boolean, desc: "Continue processing even when fonts are missing"
+        option :stylesheet, alias: "-s", desc: "Stylesheet file path for rendering HTML page"
+        option :template_dir, alias: "-t", desc: "Liquid template directory to render site design"
 
         def generate(source_path = Dir.pwd)
           Cli::SiteGenerator.generate(source_path, options, filter_compile_options(options))

--- a/spec/acceptance/generate_site_spec.rb
+++ b/spec/acceptance/generate_site_spec.rb
@@ -39,6 +39,26 @@ RSpec.describe "Metanorma" do
         Dir.pwd.to_s, any_args
       )
     end
+
+    it "supports custom template for site" do
+      template_dir = "./tmp/template"
+      stylesheet_path = "./tmp/template/style.css"
+      allow(Metanorma::Cli::SiteGenerator).to receive(:generate)
+
+      command = %W(
+        site generate #{source_dir}
+        --template-dir #{template_dir}
+        --stylesheet #{stylesheet_path}
+      )
+
+      capture_stdout { Metanorma::Cli.start(command) }
+
+      expect(Metanorma::Cli::SiteGenerator).to have_received(:generate).with(
+        source_dir.to_s,
+        hash_including(template_dir: template_dir, stylesheet: stylesheet_path),
+        {}
+      )
+    end
   end
 
   def source_dir

--- a/spec/fixtures/metanorma.yml
+++ b/spec/fixtures/metanorma.yml
@@ -35,3 +35,7 @@ metanorma:
   collection:
     organization: "Metanorma : Organization name sample"
     name: "Metanorma: Sample collection name from metanorma.yml"
+
+  template:
+      path: your-custom-template-path
+      stylesheet: stylesheed-file-path

--- a/spec/metanorma/cli/site_generator_spec.rb
+++ b/spec/metanorma/cli/site_generator_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Metanorma::Cli::SiteGenerator do
         )
 
         expect(Relaton::Cli::XMLConvertor).to have_received(:to_html).with(
-          collection_xml
+          collection_xml, nil, nil
         )
       end
     end
@@ -80,6 +80,42 @@ RSpec.describe Metanorma::Cli::SiteGenerator do
           "documents.xml",
           title: collection["name"],
           organization: collection["organization"],
+        )
+      end
+    end
+
+    context "custom site template" do
+      it "respectes template options and pass it down to relaton" do
+        stub_external_interface_calls
+
+        template_dir = "template-dir-as-option"
+        stylesheet_path = "stylesheet-as-option"
+
+        Metanorma::Cli::SiteGenerator.generate(
+          source_path,
+          output_dir: output_directory,
+          template_dir: template_dir,
+          stylesheet: stylesheet_path
+        )
+
+        expect(Relaton::Cli::XMLConvertor).to have_received(:to_html).with(
+          "documents.xml", stylesheet_path, template_dir
+        )
+      end
+
+      it "allows us to use manifest file for template" do
+        stub_external_interface_calls
+
+        Metanorma::Cli::SiteGenerator.generate(
+          source_path,
+          output_dir: output_directory,
+          config: source_path.join("metanorma.yml")
+        )
+
+        expect(Relaton::Cli::XMLConvertor).to have_received(:to_html).with(
+          "documents.xml",
+          manifest["metanorma"]["template"]["stylesheet"],
+          manifest["metanorma"]["template"]["path"]
         )
       end
     end


### PR DESCRIPTION
The current site interface is using a default template we have in the relaton library, this works great but we want to give more control to the actual user so they can use their custom styles or template

This commit adds the support for the style and template options, and once the user pass this options then we pass it down to relaton to handle it accordingly.

Normal usages wise the options are `template_dir`, and `stylesheet` but user can also use the `metanorma.yml` file to more stable config.

```ruby
metanorma:
  ...
  template:
    path: "./path-to-your-template"
    stylesheet: "./path-to-your-stylesheet-file"
```

Doc: https://github.com/relaton/relaton-cli#relaton-xml2html
Fixes: https://github.com/metanorma/mn-templates-cc/issues/3