### PR TITLE
Add simplified docker setup for development

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,27 @@
+ARG RUBY_IMAGE=ruby:3.0-buster
+
+FROM ${RUBY_IMAGE}
+
+RUN apt-get update -qq && apt-get install -yy curl wget
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+    && apt-get update && apt-get install -qq -y nodejs build-essential \
+    libxml2-dev libxslt1-dev libqtwebkit4 libqt4-dev xvfb wait-for-it \
+    openjdk-11-jdk libpq-dev --fix-missing --no-install-recommends \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# install latest bundler
+RUN gem install bundler
+RUN npm install yarn -g
+
+# Create app directory
+WORKDIR /metanorma-cli
+
+# Set bundle path
+ENV BUNDLE_PATH /bundle
+
+# Copy files
+COPY . .
+
+# Default to console
+CMD ["bin/console"]

--- a/.docker/Makefile
+++ b/.docker/Makefile
@@ -1,0 +1,25 @@
+export RUBY_IMAGE ?= ruby:3.0-buster
+
+.PHONY: up
+up:
+	docker-compose up
+
+.PHONY: down
+down:
+	docker-compose down
+
+.PHONY: test
+test: rspec
+
+.PHONY: ssh
+ssh:
+	docker-compose run cli bash
+
+.PHONY: rspec
+rspec:
+	docker-compose run cli bin/rspec
+
+.PHONY: setup
+setup:
+	docker-compose build --build-arg RUBY_IMAGE=${RUBY_IMAGE}
+	docker-compose run cli bin/setup

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+
+services:
+  cli:
+    build:
+      context: ../
+      dockerfile: ./.docker/Dockerfile
+
+    volumes:
+      - ../:/metanorma-cli
+      - bundle:/bundle
+
+volumes:
+  bundle:

--- a/.docker/readme.md
+++ b/.docker/readme.md
@@ -1,0 +1,52 @@
+## Docker
+
+This directory is only meant to be used for development, and contains some
+necessary setup to spin up docker containers with multiple ruby environment.
+
+### Setup
+
+By default it usages the most recent ruby version for docker environment, but if
+you want to run it in any specific version then you can set it up by exporting
+`RUBY_IMAGE` environment variable in your shell:
+
+```sh
+export RUBY_IMAGE=ruby:3.0-buster
+```
+
+Once everything is set then you would need to build the development images for
+the first time and you can do that using:
+
+```sh
+make setup
+```
+
+The setup process will install all dependencies and it will also setup a volume
+to speed up the repeated gem installation.
+
+### Playground
+
+The `Makefile` contains two target for tests, and you can run the tests using
+any of the following commands:
+
+```sh
+make test
+
+# or
+make rspec
+```
+
+If you need more control, and you want to do some development on the go then you
+can get into the container using:
+
+```sh
+make ssh
+```
+
+### Cleanup
+
+Once you are done with your experiment then you can cleanup the docker
+environment using the following command.
+
+```sh
+make down
+```


### PR DESCRIPTION
With the frequent changes in the project it gets bit hard sometime to setup everything in a local machine, and also test it out in multiple ruby environment to debug the project.

This commit adds a simplified way to run the project in docker and it also give us full control to switch between the version easily, hopefully it will help us to debug things quickly and make our life easy!

Note: We are explicitly including files for the gem, so this folder should not be shipped to the actual gem, but there is some changes then we can adjust those in the future.

Usages:

```
# set your ruby version
export RUBY_IMAGE=ruby:3.0-buster

# install the dependencies
make setup

# test it out
make rspec
```