### PR TITLE
WIP: Fix correct status code related tests

### DIFF
--- a/lib/metanorma/cli/compiler.rb
+++ b/lib/metanorma/cli/compiler.rb
@@ -44,6 +44,9 @@ module Metanorma
         c = Compile.new
         c.compile(file, serialize_options)
         c.errors
+
+      rescue Errno::ENOENT => error
+        [ error ]
       end
 
       def serialize_options

--- a/spec/acceptance/compile_spec.rb
+++ b/spec/acceptance/compile_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe "Metanorma" do
         expect(error.status).to eq(Errno::ENOENT::Errno)
       end
     end
+
+    it "returns with 1 status when metanorma can't handle compilation" do
+      begin
+        capture_stdout {
+          Metanorma::Cli.start(
+            %W(compile #{fixtures_path.join("mn-samples-ietf-antioch.adoc")})
+          )
+        }
+
+      rescue SystemExit => error
+        expect(error.status).to eq(1)
+      end
+    end
   end
 
   def fixtures_path

--- a/spec/metanorma/cli/compiler_spec.rb
+++ b/spec/metanorma/cli/compiler_spec.rb
@@ -15,26 +15,6 @@ RSpec.describe Metanorma::Cli::Compiler do
       end
     end
 
-    # @TODO: What exactly are we testing here?
-    # The script should exit with non zero status when errors like following occur:
-    #   [metanorma] Error: xmlrfc2 format is not supported for this standard.
-    #   [metanorma] Error: nits format is not supported for this standard.
-    # See issue 151.
-    #
-    it "compile with errors" do
-      # skip "seems like it's breaking the test suite"
-      # Try to update metanorma gem
-      VCR.use_cassette "workgroup_fetch" do
-        expect do
-          Metanorma::Cli.start(["spec/fixtures/mn-samples-ietf-antioch.adoc", "--no-install-fonts"])
-        end.to raise_error SystemExit
-
-        delete_file_if_exist("mn-samples-ietf-antioch.err")
-        delete_file_if_exist("mn-samples-ietf-antioch.rfc.xml")
-        delete_file_if_exist("mn-samples-ietf-antioch.")
-      end
-    end
-
     it "write files to specified output dir" do
       VCR.use_cassette "workgroup_fetch" do
         Dir.mktmpdir("rspec-") do |dir|


### PR DESCRIPTION
In the recent version of ruby, then complier is is raising an invalid file related issue and that is not being handled by the
metanorma. This commit adds the error handling in the CLI.

This commit also moves those acceptance tests to the right places for better test grouping.