### PR TITLE
WIP: Add support for collection options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 .rspec_status
 .vscode/
 relaton/
+*.log
 
 *.gem
 

--- a/lib/metanorma/cli/collection_parser.rb
+++ b/lib/metanorma/cli/collection_parser.rb
@@ -1,0 +1,58 @@
+require "yaml"
+
+module Metanorma
+  module Cli
+    class CollectionParser
+      def initialize(collection_file, options = {})
+        @options = options
+        @collection_file = collection_file.to_s
+      end
+
+      def self.parse(collection_file, options = {})
+        new(collection_file, options).parse
+      end
+
+      def parse
+        # puts merged_options(extract_options(yaml_content), options)
+        # puts options
+        # puts extract_options(yaml_content)
+
+        # extract out the options
+        # options = extract_options(yaml_content)
+        # puts options
+
+        # require "pry"
+        # binding.pry
+
+        # load the file
+        # metanorma_collection.render(options)
+
+        # pass it down to metanorma
+      end
+
+      def merged_options(base_options, prefered_options)
+        base_options.merge(prefered_options)
+      end
+
+      private
+
+      attr_reader :collection_file, :options
+
+      def yaml_content
+        @yaml_content ||= YAML.safe_load(File.read(collection_file))
+      end
+
+      def metanorma_collection
+        @metanorma_collection ||= Metanorma::Collection.parse(collection_file)
+      end
+
+      def extract_options(content_hash)
+        Hash.new.tap do |options|
+          options["coverpage"] ||= content_hash["cover"]
+          options["output_folder"] ||= content_hash["output_dir"]
+          options["format"] ||= content_hash["formats"]&.map(&:to_sym)
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -5,6 +5,7 @@ require "metanorma/cli/thor_with_config"
 require "metanorma/cli/commands/config"
 require "metanorma/cli/commands/template_repo"
 require "metanorma/cli/commands/site"
+require "metanorma/cli/collection_parser"
 
 module Metanorma
   module Cli
@@ -66,11 +67,16 @@ module Metanorma
 
       def collection(filename = nil)
         if filename
-          opts = options
-          opts[:format] &&= opts[:format].split(",").map &:to_sym
-          opts[:compile] = filter_compile_options(opts)
-          coll = Metanorma::Collection.parse filename
-          coll.render opts
+          # opts = options
+          # opts[:compile] = filter_compile_options(opts)
+          # coll = Metanorma::Collection.parse filename
+          # coll.render opts
+
+          col_options = options.dup
+          col_options[:compile] = filter_compile_options(col_options)
+          col_options[:format] &&= col_options[:format].split(",").map &:to_sym
+
+          Metanorma::Cli::CollectionParser.parse(filename, col_options)
         else UI.say("Need to specify a file to process")
         end
       rescue ArgumentError => e

--- a/spec/acceptance/generate_site_spec.rb
+++ b/spec/acceptance/generate_site_spec.rb
@@ -49,7 +49,11 @@ RSpec.describe "Metanorma" do
         .at_least(:once)
         .with(
           kind_of(String),
-          hash_including(format: :asciidoc, output_dir: kind_of(Pathname), continue_without_fonts: true)
+          hash_including(
+            format: :asciidoc,
+            output_dir: kind_of(Pathname),
+            continue_without_fonts: true,
+          ),
         )
     end
 
@@ -85,6 +89,6 @@ RSpec.describe "Metanorma" do
   end
 
   def source_dir
-    @source_dir ||= File.expand_path(File.join(File.dirname(__dir__), "fixtures"))
+    @source_dir ||= Metanorma::Cli.root_path.join("spec", "fixtures")
   end
 end

--- a/spec/fixtures/collection_with_options.yml
+++ b/spec/fixtures/collection_with_options.yml
@@ -1,0 +1,67 @@
+directives:
+  - documents-inline
+
+bibdata:
+  title:
+    - language: en
+      content: The International System of Units (SI)
+    - language: fr
+      content: Le Système international d’unités (SI)
+  type: collection
+  docid:
+    type: bipm
+    id: sibrochure
+  edition: 9
+  date:
+    - type: updated
+      value: "2019-05-20"
+  copyright:
+    owner:
+      name: Bureau International des Poids et Mesures
+      abbreviation: BIPM
+    from: 2019
+
+# TODO, was CLI option, not yet supported
+output_dir: bilingual-brochure
+
+# TODO, was CLI option, not yet supported
+formats:
+  - xml
+  - html
+  - presentation
+  - pdf
+
+manifest:
+  level: brochure
+  title: Brochure/Brochure
+
+  docref:
+    - fileref: site/documents/si-brochure-fr.xml
+      identifier: si-brochure-fr
+    - fileref: site/documents/si-brochure-en.xml
+      identifier: si-brochure-en
+
+
+  # TODO, not yet supported
+  # Option 1, specify built files
+  # Option 2, specify source if not built
+  # documents:  # was `docref`
+  #   - source: si-brochure-fr.adoc
+  #     identifier: si-brochure-fr
+  #
+  #     # was `fileref`
+  #     rendered: site/documents/si-brochure-fr.xml
+  #
+  #   - identifier: si-brochure-en
+  #     source: si-brochure-en.adoc
+  #     rendered: site/documents/si-brochure-en.xml
+  #
+# TODO, was CLI option, not yet supported
+cover: collection_cover.html
+
+prefatory-content:
+|
+
+
+final-content:
+|

--- a/spec/metanorma/cli/collection_parser_spec.rb
+++ b/spec/metanorma/cli/collection_parser_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe Metanorma::Cli::CollectionParser do
+  describe ".parse" do
+    it "parse the options properly" do
+      Metanorma::Cli::CollectionParser.parse(sample_collection_file)
+    end
+  end
+
+  def sample_collection_file
+    @sample_collection_file ||= Metanorma::Cli.root_path.join(
+      "spec", "fixtures", "collection_with_options.yml"
+    )
+  end
+end

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,20 @@
+### Site generate with collection
+
+On the site generator configuration: we want to add an option/field, where
+a user can provide collection file as configuration.
+
+During site generation, we want the generator to take this into consideration
+and based on this we also want to the site generator to invoke the collection
+building happening.
+
+In the collection interface, we also want to support configuration options,
+instead of passing around we also want to be specified in form of data filed
+and use that one to pass it down to the metanorma xml
+
+### Todos
+
+- [ ] Add support for collection option parsing
+- [ ] Adopt the field changes for the collection
+- [ ] Define collection config in the generator
+- [ ] Invoke the parsing from the site generator
+- [ ] Adopt this interface in collection, maybe?


### PR DESCRIPTION
**Work In Progress!**
---


On the site generator configuration: we want to add an option/field, where a user can provide collection file as configuration.

During site generation, we want the generator to take this into consideration and based on this we also want to the site generator to invoke the collection building happening.

In the collection interface, we also want to support configuration options, instead of passing around we also want to be specified in form of data filed and use that one to pass it down to the metanorma xml

### Todos

- [ ] Add support for collection option parsing
- [ ] Adopt the field changes for the collection
- [ ] Define collection config in the generator
- [ ] Invoke the parsing from the site generator
- [ ] Adopt this interface in collection, maybe?



Related: #205 