### PR TITLE
metanorma/metanorma#202 add socksify dependency and support SOCKS_PROXY env var

### DIFF
--- a/exe/metanorma
+++ b/exe/metanorma
@@ -11,8 +11,10 @@ $:.unshift File.expand_path("../../lib", bin_file)
 # Fixes https://github.com/rubygems/rubygems/issues/1420
 require "rubygems/specification"
 
-class Gem::Specification
-  def this; self; end
+module Gem
+  class Specification
+    def this; self; end
+  end
 end
 
 # start up the CLI

--- a/exe/metanorma
+++ b/exe/metanorma
@@ -17,4 +17,18 @@ end
 
 # start up the CLI
 require "metanorma/cli"
-Metanorma::Cli.start(ARGV)
+metanorma_cli = proc { Metanorma::Cli.start(ARGV) }
+if ENV["SOCKS_PROXY"]
+  require "socksify"
+  require "uri"
+  begin
+    proxy = URI.parse(ENV["SOCKS_PROXY"])
+    Socksify::proxy(proxy.host, proxy.port, &metanorma_cli)
+  rescue URI::InvalidURIError
+    warn "Value of ENV.SOCKS_PROXY=#{ENV['SOCKS_PROXY']} is invalid! Droping it"
+    ENV.delete("SOCKS_PROXY")
+    metanorma_cli.call
+  end
+else
+  metanorma_cli.call
+end

--- a/lib/metanorma/cli/git_template.rb
+++ b/lib/metanorma/cli/git_template.rb
@@ -10,16 +10,15 @@ module Metanorma
 
       def remove!
         remove_template
-        return true
+        true
       end
 
       def download
         remove!
         clone_git_template(options[:repo])
-
       rescue Git::GitExecuteError
         UI.say("Invalid template reoository!")
-        return nil
+        nil
       end
 
       def find_or_download
@@ -86,7 +85,7 @@ module Metanorma
           iso: "https://github.com/metanorma/mn-templates-iso",
           iec: "https://github.com/metanorma/mn-templates-iec",
           itu: "https://github.com/metanorma/mn-templates-itu",
-          ietf: "https://github.com/metanorma/mn-templates-ietf"
+          ietf: "https://github.com/metanorma/mn-templates-ietf",
         }
       end
 

--- a/metanorma-cli.gemspec
+++ b/metanorma-cli.gemspec
@@ -58,4 +58,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "metanorma-ogc", "~> 1.3.0"
   spec.add_runtime_dependency "metanorma-un", "~> 0.6.0"
   spec.add_runtime_dependency "relaton-cli", ">= 0.8.2"
+
+  spec.add_runtime_dependency "socksify"
 end


### PR DESCRIPTION
 - metanorma/metanorma#202

## Open questions

 - Should we handle a case git repos which were cloned with proxy and then metanorma executed without proxy? Maybe should we leave it up to the user at all to configure with `--global` git params https://gist.github.com/evantoli/f8c23a37eb3558ab8765
   - End-user will be responsible to modify ~/.gitconfig to setup proxy

## Related PRs:
 - https://github.com/fontist/fontist/pull/250

## Related other gems issues/PRs:
 - https://github.com/ruby-git/ruby-git/issues/533
 - https://github.com/ruby-git/ruby-git/pull/532