### PR TITLE
Add CLI specific collection interface

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
+--profile
 --require spec_helper

--- a/lib/metanorma/cli.rb
+++ b/lib/metanorma/cli.rb
@@ -82,6 +82,10 @@ module Metanorma
       Pathname.new(Cli.root).join("..")
     end
 
+    def self.with_indifferent_access(options)
+      Thor::CoreExt::HashWithIndifferentAccess.new(options)
+    end
+
     def self.find_command(arguments)
       commands = Metanorma::Cli::Command.all_commands.keys
       commands.select { |cmd| arguments.include?(cmd.gsub("_", "-")) == true }

--- a/lib/metanorma/cli/collection.rb
+++ b/lib/metanorma/cli/collection.rb
@@ -1,0 +1,39 @@
+module Metanorma
+  module Cli
+    class Collection
+      def initialize(file, options)
+        @file = file
+        @options = options
+      end
+
+      def self.render(filename, options = {})
+        new(filename, options).render
+      end
+
+      def render
+        collection_file.render(collection_options)
+      end
+
+      private
+
+      attr_reader :file, :options
+
+      def collection_file
+        @collection_file ||= Metanorma::Collection.parse(file)
+      end
+
+      def collection_options
+        {
+          compile: options.fetch(:compile, nil),
+          coverpage: options.fetch("coverpage", nil),
+          output_folder: options.fetch("output_folder", nil),
+          format: collection_output_formats(options.fetch("format", "")),
+        }
+      end
+
+      def collection_output_formats(format)
+        format.split(",")&.map(&:to_sym)
+      end
+    end
+  end
+end

--- a/lib/metanorma/cli/collection.rb
+++ b/lib/metanorma/cli/collection.rb
@@ -6,6 +6,7 @@ module Metanorma
       def initialize(file, options)
         @file = file
         @options = Cli.with_indifferent_access(options)
+        @compile_options = @options.delete(:compile)
       end
 
       def self.render(filename, options = {})
@@ -27,7 +28,7 @@ module Metanorma
 
       def collection_options
         {
-          compile: options.fetch(:compile, nil),
+          compile: @compile_options,
           coverpage: options.fetch(:coverpage, nil),
           output_folder: options.fetch(:output_folder, nil),
           format: collection_output_formats(options.fetch(:format, "")),

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -1,5 +1,6 @@
 require "metanorma/cli/compiler"
 require "metanorma/cli/generator"
+require "metanorma/cli/collection"
 require "metanorma/cli/git_template"
 require "metanorma/cli/thor_with_config"
 require "metanorma/cli/commands/config"
@@ -67,12 +68,11 @@ module Metanorma
 
       def collection(filename = nil)
         if filename
-          opts = options
-          opts[:format] &&= opts[:format].split(",").map &:to_sym
-          opts[:compile] = filter_compile_options(opts)
-          coll = Metanorma::Collection.parse filename
-          coll.render opts
-        else UI.say("Need to specify a file to process")
+          coll_options = options.dup
+          coll_options[:compile] = filter_compile_options(coll_options)
+          Metanorma::Cli::Collection.render(filename, coll_options)
+        else
+          UI.say("Need to specify a file to process")
         end
       rescue ArgumentError => e
         UI.say e.message

--- a/spec/acceptance/collection_spec.rb
+++ b/spec/acceptance/collection_spec.rb
@@ -1,0 +1,44 @@
+RESULTS = "spec/results".freeze
+
+RSpec.describe "Collection" do
+  describe "collection" do
+    it "render HTML from YAML" do
+      run_metanorma_collection("collection1.yml")
+      expect_generated_files_to_match_expectations
+    end
+
+    it "Render HTML from XML" do
+      run_metanorma_collection("collection1.xml")
+      expect_generated_files_to_match_expectations
+    end
+  end
+
+  around(:each) do |example|
+    Dir.mktmpdir("rspec-") do |temp_directory|
+      FileUtils.cp(Dir.glob("spec/fixtures/*"), temp_directory)
+      Dir.chdir(temp_directory) { example.run }
+    end
+  end
+
+  def run_metanorma_collection(filename)
+    command = %W(
+      collection #{filename}
+      -x html
+      -w #{RESULTS}
+      -c collection_cover.html
+      --no-install-fonts
+    )
+
+    capture_stdout { Metanorma::Cli.start(command) }
+  end
+
+  def expect_generated_files_to_match_expectations
+    expected_files.each do |file|
+      expect(File.exist?(File.join(RESULTS, file))).to be_truthy
+    end
+  end
+
+  def expected_files
+    %w(index.html rice-amd.final.html rice-en.final.html rice1-en.final.html)
+  end
+end

--- a/spec/fixtures/collection_with_options.yml
+++ b/spec/fixtures/collection_with_options.yml
@@ -1,0 +1,70 @@
+# Embedded options
+#
+# output directory
+output_folder: bilingual-brochure
+
+# coverpage
+coverpage: collection_cover.html
+
+# formats
+format:
+  - xml
+  - html
+  - presentation
+  - pdf
+
+# directives are YAML-specific instructions
+directives:
+  # - documents-inline
+  # to inject the XML into the collection manifest; 
+  - documents-external 
+  # keeps them outside
+bibdata:
+  title:
+    type: title-main
+    language: en
+    content: ISO Collection 1
+  type: collection
+  docid:
+    type: iso
+    id: ISO 12345
+  edition: 1
+  date:
+    - type: created
+      value: "2020"
+    - type: issued
+      value: "2020"
+  copyright:
+    owner:
+      name: International Organization for Standardization
+      abbreviation: ISO
+    from: "2020"
+
+manifest:
+  level: collection
+  title: ISO Collection 
+  manifest:
+    - level: subcollection
+      title: Standards
+      docref:
+        - fileref: rice-en.final.xml
+          identifier: ISO 17301-1:2016
+        - fileref: dummy.xml
+          identifier: ISO 17302
+        - fileref: rice1-en.final.xml
+          identifier: ISO 1701:1974
+    - level: subcollection
+      title: Amendments
+      docref:
+        fileref: rice-amd.final.xml
+        identifier: ISO 17301-1:2016/Amd.1:2017
+prefatory-content: 
+|
+
+  == Clause
+  Welcome to our collection
+
+final-content:
+|
+  == Exordium
+  Hic explicit

--- a/spec/fixtures/metanorma.yml
+++ b/spec/fixtures/metanorma.yml
@@ -26,6 +26,9 @@ metanorma:
       - ./sample.adoc
       - ./sample-itu.adoc
 
+      # collection file
+      - ./collection_with_options.yml
+
 # Required: Site metadata
 #
 # The following relaton node is required for site generation.

--- a/spec/metanorma/cli/collection_spec.rb
+++ b/spec/metanorma/cli/collection_spec.rb
@@ -1,30 +1,18 @@
-RESULTS = "spec/results".freeze
+require "spec_helper"
 
-RSpec.describe "Collection" do
-  around(:each) do |example|
-    Dir.mktmpdir("rspec-") do |dir|
-      FileUtils.cp Dir.glob("spec/fixtures/*"), dir
-      Dir.chdir(dir) { example.run }
+RSpec.describe Metanorma::Cli::Collection do
+  describe ".render" do
+    context "with specified options" do
+      it "compiles and renders the collection files" do
+        allow(Metanorma::Collection).to receive_message_chain(:parse, :render)
+        Metanorma::Cli::Collection.render(collection_file, format: "html")
+      end
     end
   end
 
-  it "render HTML from YAML" do
-    Metanorma::Cli.start [
-      "collection", "collection1.yml", "-x", "html", "-w", RESULTS, "-c", "collection_cover.html", "--no-install-fonts"
-    ]
-    expect_results
-  end
-
-  it "Render HTML from XML" do
-    Metanorma::Cli.start [
-      "collection", "collection1.xml", "-x", "html", "-w", RESULTS, "-c", "collection_cover.html", "--no-install-fonts"
-    ]
-    expect_results
-  end
-
-  def expect_results
-    %w[index.html dummy.html rice-amd.final.html rice-en.final.html rice1-en.final.html].each do |file|
-      expect(File.exist?(File.join(RESULTS, file))).to be_truthy
-    end
+  def collection_file
+    @collection_file ||= Metanorma::Cli.root_path.join(
+      "spec", "fixtures", "collection1.yml"
+    )
   end
 end

--- a/spec/metanorma/cli/collection_spec.rb
+++ b/spec/metanorma/cli/collection_spec.rb
@@ -4,15 +4,37 @@ RSpec.describe Metanorma::Cli::Collection do
   describe ".render" do
     context "with specified options" do
       it "compiles and renders the collection files" do
-        allow(Metanorma::Collection).to receive_message_chain(:parse, :render)
-        Metanorma::Cli::Collection.render(collection_file, format: "html")
+        collection = mock_collection_instance
+        Metanorma::Cli::Collection.render(collection_file, format: "html, pdf")
+
+        expect(collection).to have_received(:render).with(format: %I(html pdf))
+      end
+    end
+
+    context "with embedded options" do
+      it "extracts options from file and renders collection" do
+        collection = mock_collection_instance
+
+        collection_file = collection_file("collection_with_options.yml")
+        Metanorma::Cli::Collection.render(collection_file)
+
+        expect(collection).to have_received(:render).with(
+          coverpage: "collection_cover.html",
+          output_folder: "bilingual-brochure",
+          format: %I(xml html presentation pdf),
+        )
       end
     end
   end
 
-  def collection_file
-    @collection_file ||= Metanorma::Cli.root_path.join(
-      "spec", "fixtures", "collection1.yml"
-    )
+  def collection_file(collection = "collection1.yml")
+    Metanorma::Cli.root_path.join("spec", "fixtures", collection)
+  end
+
+  def mock_collection_instance
+    collection = double(Metanorma::Collection, parse: nil, render: nil)
+    allow(Metanorma::Collection).to receive(:parse).and_return(collection)
+
+    collection
   end
 end


### PR DESCRIPTION
Currently, the collection command is directly invoking the collection interface from the metanorma core library but this commit changes this and add a collection interface in the CLI.

This interface will allow us to prepare the necessary options and additionally we can also extend this interface to read options form file as well.