### PR TITLE
Gracefully handle keyboard interruption

### DIFF
--- a/lib/metanorma/cli.rb
+++ b/lib/metanorma/cli.rb
@@ -32,7 +32,8 @@ module Metanorma
       end
 
       Metanorma::Cli::Command.start(arguments)
-
+    rescue Interrupt, SignalException => _e
+      UI.say("Good Bye!")
     rescue Errors::FileNotFoundError => error
       UI.say("Error: #{error}. \nNot sure what to run? try: metanorma help")
       exit(Errno::ENOENT::Errno)


### PR DESCRIPTION
Let's say, we are running the `metanorma` command, and for whatever reason if we want to exit the process (CTRL-C, and others) and don't continue with the command then it blows up with error with in the terminal with useless back tracing information.

This commit changes that, so now if we try to exit the process then it should gracefully handle the signal, show a simple message.
