### PR TITLE
Fix collection option related issue

### DIFF
--- a/lib/metanorma/cli/collection.rb
+++ b/lib/metanorma/cli/collection.rb
@@ -26,11 +26,15 @@ module Metanorma
         @collection_file ||= Metanorma::Collection.parse(file)
       end
 
+      def source_folder
+        @source_folder ||= File.dirname(File.expand_path(file))
+      end
+
       def collection_options
-        {
+        @collection_options ||= {
           compile: @compile_options,
           coverpage: options.fetch(:coverpage, nil),
-          output_folder: options.fetch(:output_folder, nil),
+          output_folder: options.fetch(:output_folder, source_folder),
           format: collection_output_formats(options.fetch(:format, "")),
         }
       end

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -59,7 +59,7 @@ module Metanorma
 
       desc "collection FILENAME", "Render HTML pages from XML/YAML colection"
       option :format, aliases: "-x", type: :string, desc: "Formats to generate"
-      option :output_folder, aliases: "-w", required: true, desc: "Directory to save compiled files"
+      option :output_folder, aliases: "-w", desc: "Directory to save compiled files"
       option :coverpage, aliases: "-c", desc: "Liquid template"
       option :agree_to_terms, type: :boolean, desc: "Agree / Disagree with all third-party licensing terms "\
                                                     "presented (WARNING: do know what you are agreeing with!)"

--- a/spec/metanorma/cli/collection_spec.rb
+++ b/spec/metanorma/cli/collection_spec.rb
@@ -5,9 +5,16 @@ RSpec.describe Metanorma::Cli::Collection do
     context "with specified options" do
       it "compiles and renders the collection files" do
         collection = mock_collection_instance
-        Metanorma::Cli::Collection.render(collection_file, format: "html, pdf")
 
-        expect(collection).to have_received(:render).with(format: %I(html pdf))
+        Metanorma::Cli::Collection.render(
+          collection_file,
+          format: "html, pdf",
+          output_folder: "bilingual-brochure",
+        )
+
+        expect(collection).to have_received(:render).with(
+          format: %I(html pdf), output_folder: "bilingual-brochure",
+        )
       end
     end
 
@@ -22,6 +29,18 @@ RSpec.describe Metanorma::Cli::Collection do
           coverpage: "collection_cover.html",
           output_folder: "bilingual-brochure",
           format: %I(xml html presentation pdf),
+        )
+      end
+    end
+
+    context "with missing options" do
+      it "usages the source as reference for options" do
+        collection = mock_collection_instance
+
+        Metanorma::Cli::Collection.render(collection_file)
+
+        expect(collection).to have_received(:render).with(
+          hash_including(output_folder: File.dirname(collection_file.to_s)),
         )
       end
     end


### PR DESCRIPTION
We have recently added support to provide collection options either as a command line arguments or options in collection file. But that is only working on the site interface, and the collection cli still expect the `output-folder` as required option.

This commit changes that, so it's not required anymore and it will try to read the option from the file, and if none of those source has this value, then it will use the source as output directory.

Fixes https://github.com/metanorma/metanorma-cli/issues/283