### PR TITLE
Fix site generated collection's output path

### DIFF
--- a/lib/metanorma/cli/collection.rb
+++ b/lib/metanorma/cli/collection.rb
@@ -6,6 +6,7 @@ module Metanorma
       def initialize(file, options)
         @file = file
         @options = Cli.with_indifferent_access(options)
+        @output_dir = @options.delete(:output_dir)
         @compile_options = @options.delete(:compile)
       end
 
@@ -33,10 +34,20 @@ module Metanorma
       def collection_options
         @collection_options ||= {
           compile: @compile_options,
+          output_folder: build_output_folder,
           coverpage: options.fetch(:coverpage, nil),
-          output_folder: options.fetch(:output_folder, source_folder),
           format: collection_output_formats(options.fetch(:format, "")),
         }
+      end
+
+      def build_output_folder
+        output_folder = options.fetch(:output_folder, nil)
+
+        if output_folder && @output_dir
+          @output_dir.join(output_folder).to_s
+        else
+          output_folder || source_folder
+        end
       end
 
       def collection_output_formats(formats)

--- a/lib/metanorma/cli/site_generator.rb
+++ b/lib/metanorma/cli/site_generator.rb
@@ -178,7 +178,11 @@ module Metanorma
         job = @collection_queue.pop
 
         if job
-          Cli::Collection.render(job, compile: @compile_options)
+          Cli::Collection.render(
+            job,
+            compile: @compile_options,
+            output_dir: @asset_directory.join(".."),
+          )
         end
       end
     end

--- a/spec/metanorma/cli/collection_spec.rb
+++ b/spec/metanorma/cli/collection_spec.rb
@@ -20,15 +20,18 @@ RSpec.describe Metanorma::Cli::Collection do
 
     context "with embedded options" do
       it "extracts options from file and renders collection" do
+        root_path = Metanorma::Cli.root_path
         collection = mock_collection_instance
-
         collection_file = collection_file("collection_with_options.yml")
-        Metanorma::Cli::Collection.render(collection_file)
+
+        Metanorma::Cli::Collection.render(
+          collection_file, output_dir: root_path
+        )
 
         expect(collection).to have_received(:render).with(
           coverpage: "collection_cover.html",
-          output_folder: "bilingual-brochure",
           format: %I(xml html presentation pdf),
+          output_folder: root_path.join("bilingual-brochure").to_s,
         )
       end
     end

--- a/spec/metanorma/cli/site_generator_spec.rb
+++ b/spec/metanorma/cli/site_generator_spec.rb
@@ -127,7 +127,9 @@ RSpec.describe Metanorma::Cli::SiteGenerator do
         collection_file = source_path.join("collection_with_options.yml")
 
         expect(Metanorma::Cli::Collection).to have_received(:render).with(
-          collection_file.to_s, compile: { continue_without_fonts: false }
+          collection_file.to_s,
+          output_dir: output_directory,
+          compile: { continue_without_fonts: false },
         )
       end
     end


### PR DESCRIPTION
The current collection generation doesn't take the site generated path into consideration when that's being invoked by the site generate command. This commit fixes that, so if the it was specified with any root directory, then it will take that into consideration to build the output directory.

Fixes: #284