### PR TITLE
`site generate`: Allow the first argument to be the site manifest path

### DIFF
--- a/lib/metanorma/cli/commands/site.rb
+++ b/lib/metanorma/cli/commands/site.rb
@@ -10,14 +10,16 @@ module Metanorma
       class Site < ThorWithConfig
         SITE_OUTPUT_DIRNAME = "_site"
 
-        desc "generate [SOURCE_PATH]", "Generate site from collection"
+        desc "generate [SITE_MANIFEST_PATH]", "Generate site from collection"
         option :config,
                aliases: "-c",
-               desc: "Metanorma configuration file"
+               desc: "Metanorma configuration file " \
+                     "(deprecated: use the first argument of " \
+                     "the command instead)"
 
         option :output_dir,
                aliases: "-o",
-               default: Pathname.new(Dir.pwd).join(SITE_OUTPUT_DIRNAME).to_s,
+               default: Pathname.pwd.join(SITE_OUTPUT_DIRNAME).to_s,
                desc: "Output directory for generated site"
 
         option :output_filename_template,
@@ -41,22 +43,80 @@ module Metanorma
 
         option :stylesheet,
                aliases: "-s",
-               desc: "Stylesheet file path for rendering HTML page"
+               desc: "Stylesheet file path " \
+                     "(relative to the current working directory) " \
+                     "for rendering HTML page"
 
         option :template_dir,
                aliases: "-t",
-               desc: "Liquid template directory to render site design"
+               desc: "Liquid template directory " \
+                     "(relative to the current working directory) " \
+                     "to render site design"
 
         option :strict,
                aliases: "-S",
                type: :boolean,
                desc: "Strict compilation: abort if there are any errors"
 
-        def generate(source_path = Dir.pwd)
+        # If no argument is provided, work out the base
+        # path to use for calculation of full paths for
+        # files referenced in the site manifest.
+        #
+        # Additionally, if the config file is not provided,
+        # use the current working directory as the base path.
+        # If the config file is provided, use the directory
+        # of the config file as the base path.
+        #
+        # If the source path is a file and no config file is provided,
+        # treat the source path as the config file.
+        # Similar to the above, use the directory of the config file
+        # as the base path.
+        #
+        # For stylesheet and template_dir options, and if they are
+        # relative paths, they will be resolved relative to whatever
+        # defined them.
+        #
+        # So, if they are provided via the command line,
+        # resolve them relative to the current working directory.
+        # If they are provided via the site manifest,
+        # resolve them relative to the site manifest's directory.
+        def generate(manifest_path = nil)
+          my_options = options.dup # because options is not modifiable
+
+          base_path = if manifest_path.nil?
+                        config_file = options[:config]
+                        config_file_path = if config_file.nil?
+                                             nil
+                                           else
+                                             Pathname.new(config_file)
+                                           end
+                        if config_file_path.nil?
+                          Pathname.pwd
+                        else
+                          config_file_path.dirname
+                        end
+                      elsif File.file?(manifest_path) && options[:config].nil?
+                        my_options["config"] = manifest_path
+                        Pathname.new(manifest_path).dirname
+                      else
+                        Pathname.new(manifest_path)
+                      end
+
+          base_path = base_path.realpath
+
+          %i[stylesheet template_dir].each do |key|
+            if my_options[key]
+              path = Pathname.new(my_options[key])
+              if path.relative?
+                my_options[key] = Pathname.pwd.join(path)
+              end
+            end
+          end
+
           Cli::SiteGenerator.generate!(
-            source_path,
-            options,
-            filter_compile_options(options),
+            base_path,
+            my_options,
+            filter_compile_options(my_options),
           )
           UI.say("Site has been generated at #{options[:output_dir]}")
         rescue Cli::Errors::InvalidManifestFileError

--- a/lib/metanorma/cli/site_generator.rb
+++ b/lib/metanorma/cli/site_generator.rb
@@ -34,11 +34,11 @@ module Metanorma
           template_data("output_filename"),
         )
 
-        # Determine base path for template files
-        # If template_dir is not absolute, then it is relative to the manifest
-        # file.
-        # If manifest file is not provided, then it is relative to the current
-        # directory.
+        # Determine base path for stylesheet & template files
+        # If the file path is relative, it is relative to the directory
+        # containing the site manifest file.
+        # If site manifest file is not provided, then it is relative to the
+        # current directory.
         @base_path = if manifest_file.nil?
                        Pathname.pwd
                      else

--- a/spec/acceptance/generate_site_spec.rb
+++ b/spec/acceptance/generate_site_spec.rb
@@ -1,6 +1,8 @@
-require "spec_helper"
+# frozen_string_literal: true
 
 RSpec.describe "Metanorma" do
+  let(:source_dir) { Pathname.new(__dir__).parent.join("fixtures") }
+
   around(:each) do |example|
     Dir.mktmpdir("rspec-") do |dir|
       Dir.chdir(dir) { example.run }
@@ -19,7 +21,7 @@ RSpec.describe "Metanorma" do
 
       expect(output).to include("Site has been generated at #{output_dir}")
       expect(Metanorma::Cli::SiteGenerator).to have_received(:generate!).with(
-        source_dir.to_s,
+        source_dir,
         {
           output_dir: output_dir,
           progress: false,
@@ -52,7 +54,7 @@ RSpec.describe "Metanorma" do
 
       expect(output).to include("Site has been generated at #{output_dir}")
       expect(Metanorma::Cli::SiteGenerator).to have_received(:generate!).with(
-        source_dir.to_s,
+        source_dir,
         {
           output_dir: output_dir,
           progress: false,
@@ -85,7 +87,7 @@ RSpec.describe "Metanorma" do
       Metanorma::Cli.start(%w(site generate))
 
       expect(Metanorma::Cli::SiteGenerator).to have_received(:generate!).with(
-        Dir.pwd.to_s, any_args
+        Pathname.pwd, any_args
       )
     end
 
@@ -103,8 +105,9 @@ RSpec.describe "Metanorma" do
       capture_stdout { Metanorma::Cli.start(command) }
 
       expect(Metanorma::Cli::SiteGenerator).to have_received(:generate!).with(
-        source_dir.to_s,
-        hash_including(template_dir: template_dir, stylesheet: stylesheet_path),
+        source_dir,
+        hash_including(template_dir: Pathname.pwd.join(template_dir),
+                       stylesheet: Pathname.pwd.join(stylesheet_path)),
         progress: false,
         install_fonts: true,
       )
@@ -144,10 +147,5 @@ RSpec.describe "Metanorma" do
       expect(exit_called).to eq(true)
       expect(output).to include("Fatal compilation error(s)")
     end
-  end
-
-  def source_dir
-    @source_dir ||=
-      File.expand_path(File.join(File.dirname(__dir__), "fixtures"))
   end
 end


### PR DESCRIPTION
This PR builds on #376.

Fixes #379 which in turn resolves #377.

It is not a breaking change --- existing workflows will continue to work.

But documentation needs updating as to the recommended way of invoking `site generate`, which is to explicitly specify where the site manifest file is, as its first argument.

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [x] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
