### PR TITLE
fix: temporarily disable plateau, somehow memory usage is killing GitHub Actions now (something changed)

### DIFF
--- a/.github/workflows/samples-smoke-matrix.json
+++ b/.github/workflows/samples-smoke-matrix.json
@@ -227,20 +227,6 @@
           }
         }
       }
-    },
-    {
-      "id": "plateau",
-      "public": true,
-      "experimental": false,
-      "manifest": {
-        "metanorma": {
-          "source": {
-            "files": [
-              "sources/002-v5/document.adoc"
-            ]
-          }
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
fix: temporarily disable plateau, somehow memory usage is killing GitHub Actions now (something changed)

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
