### PR TITLE
[bisect, do not merge] pin lutaml-model 0.8.7 to isolate iso-3.3-ubuntu slowdown: https://github.com/metanorma/metanorma-cli/issues/414

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,9 @@
+# Diagnostic pin for https://github.com/metanorma/metanorma-cli/issues/414.
+# Holds lutaml-model at the last pre-regression release while fontist
+# floats to current latest, so a rake-workflow run on this branch isolates
+# the lutaml-model contribution to the iso-3.3-ubuntu-latest slowdown.
+# Loaded by mn-processor-rake.yml via `eval_gemfile("../Gemfile.devel")`
+# from each sample-repo's Gemfile during the `test-samples` job.
+# Do not merge — delete branch after the diagnostic run completes.
+
+gem "lutaml-model", "0.8.7"


### PR DESCRIPTION
## Diagnostic — do not merge

Pins `lutaml-model` to `0.8.7` (the last pre-regression release) while letting `fontist` float to the current latest (`3.0.5`). Companion to #415 which pins `fontist` to `3.0.3` with `lutaml-model` floating.

Together the two PRs fill the 2×2 (fontist × lutaml-model) matrix described in the [issue comment](https://github.com/metanorma/metanorma-cli/issues/414#issuecomment-4471449177) and isolate which gem release introduced the compile-time slowdown.

**Outcome interpretation:**

| Sibling PR #415 (fontist=3.0.3, lutaml=0.8.9) | This PR (fontist=3.0.5, lutaml=0.8.7) | Conclusion |
|---|---|---|
| fast | slow | fontist is the sole culprit |
| slow | fast | lutaml-model is the sole culprit |
| fast | fast | both contribute additively |
| slow | slow | a third change is in play; widen the bisect |

The `iso-3.3-ubuntu-latest` job duration is the headline measurement — it's the only one that hit the 6-h timeout on the latest `main` release-tag run ([v1.16.2](https://github.com/metanorma/metanorma-cli/actions/runs/25949664012)).

Will be closed without merging once the rake-workflow run completes and the duration is read back into the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
