### PR TITLE
[bisect, do not merge] pin lutaml-model 0.8.8 to narrow regression to .8 vs .9: https://github.com/metanorma/metanorma-cli/issues/414

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,9 @@
+# Diagnostic pin for https://github.com/metanorma/metanorma-cli/issues/414.
+# Narrows the lutaml-model regression window: prior cycle established that
+# 0.8.7 is fast and 0.8.9 is slow. This pin tests 0.8.8 to tell whether
+# the regression entered in 0.8.8 or in 0.8.9.
+# Loaded by mn-processor-rake.yml via `eval_gemfile("../Gemfile.devel")`
+# from each sample-repo's Gemfile during the `test-samples` job.
+# Do not merge — delete branch after the diagnostic run completes.
+
+gem "lutaml-model", "0.8.8"


### PR DESCRIPTION
## Diagnostic — do not merge

Second-cycle narrowing for https://github.com/metanorma/metanorma-cli/issues/414.

The first cycle ([PR #415](https://github.com/metanorma/metanorma-cli/pull/415) + [PR #416](https://github.com/metanorma/metanorma-cli/pull/416)) confirmed lutaml-model owns the entire regression and fully exonerated fontist 3.0.4/3.0.5. This PR narrows the lutaml-model window: pins `lutaml-model=0.8.8` with `fontist` floating to 3.0.5 (current latest).

**Outcome interpretation:**

| `iso-3.3-ubuntu-latest` duration on this PR | Conclusion |
|---|---|
| ~37m (matches baseline) | regression entered in **0.8.9** |
| ~5h (matches PR #415) | regression entered in **0.8.8** |
| intermediate | regression is split between 0.8.8 and 0.8.9 (additive) |

The `0.8.7 → 0.8.8` commit log carries two `perf:` commits that are the most likely suspects on prior — `perf: add WeakRef Store, class-identity Transform cache, DeepDupable protocol, frozen XmlElement order` and `perf: define register-specific methods at class level instead of per-instance`. The `0.8.8 → 0.8.9` log is a single autoload fix, unlikely to regress compile time.

Will be closed without merging once the rake-workflow run completes and the duration is added to the consolidated 5-column table on issue #414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
