### PR TITLE
Add 'suma' gem to metanorma version output

### DIFF
--- a/lib/metanorma/cli/flavor.rb
+++ b/lib/metanorma/cli/flavor.rb
@@ -109,7 +109,7 @@ module Metanorma
            metanorma-core metanorma-plugin-glossarist metanorma-plugin-lutaml
            metanorma-taste relaton-cli pubid glossarist fontist
            plurimath lutaml expressir xmi lutaml-model emf2svg unitsml
-           vectory ogc-gml oscal).freeze
+           vectory ogc-gml oscal suma).freeze
 
       def dependencies_versions
         versions = Gem.loaded_specs


### PR DESCRIPTION
The `suma` gem is already a runtime dependency in the gemspec but was missing from `DEPENDENCY_GEMS`, so its version was not displayed by `metanorma version`.

## Changes
- Added `suma` to the `DEPENDENCY_GEMS` constant in `lib/metanorma/cli/flavor.rb`

This is a one-line addition; the gem is already bundled and loaded at runtime.