### PR TITLE
Add output-format selection to site generate

### DIFF
--- a/lib/metanorma/cli/commands/site.rb
+++ b/lib/metanorma/cli/commands/site.rb
@@ -58,6 +58,13 @@ module Metanorma
                type: :boolean,
                desc: "Strict compilation: abort if there are any errors"
 
+        option :extensions,
+               aliases: "-x",
+               desc: "Comma-separated list of output formats to generate " \
+                     "(e.g. html,rxl); overrides the manifest `extensions:` " \
+                     "key and any per-collection `format:`. " \
+                     "Default: all formats the flavor supports"
+
         # If no argument is provided, work out the base
         # path to use for calculation of full paths for
         # files referenced in the site manifest.

--- a/lib/metanorma/cli/site_generator.rb
+++ b/lib/metanorma/cli/site_generator.rb
@@ -12,7 +12,7 @@ module Metanorma
       DEFAULT_SITE_INDEX = "index.html"
       DEFAULT_CONFIG_FILE = "metanorma.yml"
 
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def initialize(source_path, options = {}, compile_options = {})
         @collection_queue = []
         @source_path = find_realpath(source_path)
@@ -46,8 +46,16 @@ module Metanorma
                      end
 
         @compile_options = compile_options
+
+        # Resolve the output formats to generate: CLI `--extensions` (a
+        # comma-separated string in compile_options) takes precedence over the
+        # manifest `extensions:` list; empty means "all formats the flavor
+        # supports" (the historical default).  Remove it from @compile_options
+        # so it is injected explicitly and not double-handled downstream.
+        @extensions = resolve_extensions
+        @compile_options.delete(:extensions)
       end
-      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def self.generate!(source, options = {}, compile_options = {})
         new(source, options, compile_options).generate!
@@ -189,9 +197,10 @@ module Metanorma
           format: :asciidoc,
           output_dir: ensure_site_asset_output_sub_directory!(file_path),
           site_generate: true,
+          baseassetpath: Pathname.new(file_path.to_s).dirname.to_s,
+          **extensions_option,
         )
 
-        options[:baseassetpath] = Pathname.new(file_path.to_s).dirname.to_s
         Metanorma::Cli::Compiler.compile(file_path.to_s, options)
       end
 
@@ -257,20 +266,37 @@ module Metanorma
       end
 
       def manifest_config(manifest_model)
+        mn = manifest_model&.metanorma
         {
-          files: manifest_model&.metanorma&.source&.files || [],
-          template: manifest_model&.metanorma&.template,
-          collection_name: manifest_model
-            .metanorma
-            .collection
-            .name,
-          collection_organization: manifest_model
-            .metanorma
-            .collection
-            .organization,
+          files: mn&.source&.files || [],
+          template: mn&.template,
+          extensions: mn&.extensions || [],
+          collection_name: mn.collection.name,
+          collection_organization: mn.collection.organization,
         }
       rescue NoMethodError
         raise Errors::InvalidManifestFileError.new("Invalid manifest file")
+      end
+
+      # @return [Array<String>] the output formats to generate, resolved from
+      # the CLI `--extensions` flag (highest precedence) then the manifest
+      # `extensions:` list.  Empty array means "all formats" (no filtering).
+      def resolve_extensions
+        cli = @compile_options[:extensions]
+        cli = cli.split(",") if cli.is_a?(String)
+        cli = (cli || []).map(&:strip).reject(&:empty?)
+        return cli unless cli.empty?
+
+        manifest[:extensions] || []
+      end
+
+      # Restrict output formats when extensions were requested (CLI or
+      # manifest); Compiler turns this into `extension_keys`.  Empty means no
+      # filtering (all formats the flavor supports).
+      def extensions_option
+        return {} if @extensions.empty?
+
+        { extensions: @extensions.join(",") }
       end
 
       def source_from_manifest
@@ -349,12 +375,18 @@ module Metanorma
       #
       def compile_collections!
         @collection_queue.compact.each do |file|
-          Cli::Collection.render(
-            file.to_s,
+          render_options = {
             compile: @compile_options,
             output_dir: asset_directory,
             site_generate: true,
-          )
+          }
+
+          # Override each collection file's own `format:` when extensions were
+          # requested (CLI or manifest); passed-in options win over the
+          # file-extracted ones in Cli::Collection.
+          render_options[:format] = @extensions unless @extensions.empty?
+
+          Cli::Collection.render(file.to_s, render_options)
         end
       end
     end

--- a/lib/metanorma/cli/thor_with_config.rb
+++ b/lib/metanorma/cli/thor_with_config.rb
@@ -22,6 +22,7 @@ module Metanorma
             continue_without_fonts
             progress
             strict
+            extensions
           ]
           options.select { |k, _| copts.include?(k) }.symbolize_all_keys
         end

--- a/lib/metanorma/site_manifest.rb
+++ b/lib/metanorma/site_manifest.rb
@@ -23,6 +23,7 @@ module Metanorma
       attribute :source, SourceEntries
       attribute :collection, SiteMetadata
       attribute :template, SiteTemplate
+      attribute :extensions, :string, collection: true
     end
 
     class Base < Lutaml::Model::Serializable

--- a/spec/acceptance/generate_site_spec.rb
+++ b/spec/acceptance/generate_site_spec.rb
@@ -81,6 +81,24 @@ RSpec.describe "Metanorma" do
         )
     end
 
+    it "generate a mini site with selected output formats" do
+      output_dir = Dir.pwd
+      allow(Metanorma::Cli::SiteGenerator).to receive(:generate!)
+        .and_call_original
+      allow(Metanorma::Cli::Compiler).to receive(:compile)
+      command = %W(site generate #{source_dir} -o #{output_dir} -x rxl)
+
+      output = capture_stdout { Metanorma::Cli.start(command) }
+
+      expect(output).to include("Site has been generated at #{output_dir}")
+      expect(Metanorma::Cli::Compiler).to have_received(:compile)
+        .at_least(:once)
+        .with(
+          kind_of(String),
+          hash_including(format: :asciidoc, extensions: "rxl"),
+        )
+    end
+
     it "usages pwd as default source path" do
       allow(Metanorma::Cli::SiteGenerator).to receive(:generate!)
 

--- a/spec/fixtures/metanorma.yml
+++ b/spec/fixtures/metanorma.yml
@@ -27,6 +27,18 @@ metanorma:
       - ./collection_with_options.yml
       - ./collection_with_options2.yml
 
+  # Optional: Output formats
+  #
+  # The `extensions` node restricts which output formats are generated for all
+  # sources in this run (individual documents and collection files alike),
+  # overriding any per-collection `format:`. Omit it to generate every format
+  # the flavor supports. It can also be set on the command line with
+  # `--extensions` / `-x`, which takes precedence over this node.
+  #
+  # extensions:
+  #   - html
+  #   - rxl
+
   # Required: Site metadata
   #
   # The `collection.name` node specifies the site title, whereas

--- a/spec/metanorma/cli/site_generator_spec.rb
+++ b/spec/metanorma/cli/site_generator_spec.rb
@@ -281,6 +281,110 @@ RSpec.describe Metanorma::Cli::SiteGenerator do
       end
     end
 
+    context "with output format extensions" do
+      let(:collection_name) { "Ext Collection" }
+      let(:collection_org) { "Ext Org" }
+
+      let(:manifest_with_extensions) { <<~YAML }
+        metanorma:
+          source:
+            files:
+              - "*.adoc"
+          collection:
+            name: #{collection_name.inspect}
+            organization: #{collection_org.inspect}
+          extensions:
+            - html
+            - rxl
+      YAML
+
+      it "passes the manifest extensions: list to the compiler" do
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read)
+          .with(manifest_file_path.to_s)
+          .and_return(manifest_with_extensions)
+
+        described_class.generate!(
+          source_path,
+          { output_dir: output_directory, config: manifest_file_path },
+          continue_without_fonts: false,
+        )
+
+        expect(Metanorma::Cli::Compiler).to have_received(:compile).with(
+          kind_of(String),
+          hash_including(extensions: "html,rxl"),
+        ).at_least(:once)
+      end
+
+      it "passes the CLI extensions to the compiler" do
+        described_class.generate!(
+          source_path,
+          { output_dir: output_directory },
+          continue_without_fonts: false,
+          extensions: "rxl",
+        )
+
+        expect(Metanorma::Cli::Compiler).to have_received(:compile).with(
+          kind_of(String),
+          hash_including(extensions: "rxl"),
+        ).at_least(:once)
+      end
+
+      it "lets the CLI extensions override the manifest" do
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read)
+          .with(manifest_file_path.to_s)
+          .and_return(manifest_with_extensions)
+
+        described_class.generate!(
+          source_path,
+          { output_dir: output_directory, config: manifest_file_path },
+          continue_without_fonts: false,
+          extensions: "pdf",
+        )
+
+        expect(Metanorma::Cli::Compiler).to have_received(:compile).with(
+          kind_of(String), hash_including(extensions: "pdf")
+        ).at_least(:once)
+
+        expect(Metanorma::Cli::Compiler).not_to have_received(:compile).with(
+          kind_of(String), hash_including(extensions: "html,rxl")
+        )
+      end
+
+      it "overrides each collection's own format: with the extensions" do
+        allow(Metanorma::Cli::Collection).to receive(:render)
+
+        described_class.generate!(
+          source_path,
+          {
+            output_dir: output_directory,
+            config: source_path.join("metanorma.yml"),
+            site_generate: true,
+          },
+          continue_without_fonts: false,
+          extensions: "rxl",
+        )
+
+        expect(Metanorma::Cli::Collection).to have_received(:render).with(
+          source_path.join("collection_with_options.yml").to_s,
+          hash_including(format: ["rxl"]),
+        ).at_least(:once)
+      end
+
+      it "does not set extensions when none are requested" do
+        described_class.generate!(
+          source_path,
+          { output_dir: output_directory },
+          continue_without_fonts: false,
+        )
+
+        expect(Metanorma::Cli::Compiler).not_to have_received(:compile).with(
+          kind_of(String), hash_including(:extensions)
+        )
+      end
+    end
+
     context "custom site template" do
       context "without manifest file" do
         let(:expected_base_path) { Pathname.pwd }

--- a/spec/metanorma/site_manifest_spec.rb
+++ b/spec/metanorma/site_manifest_spec.rb
@@ -166,5 +166,27 @@ RSpec.describe Metanorma::SiteManifest do
       its(:'template.path') { is_expected.to eq "path/to/template" }
       its(:'template.stylesheet') { is_expected.to eq "path/to/stylesheet" }
     end
+
+    context "with a valid input YAML with output extensions" do
+      let(:input_yaml) do
+        <<~EOYAML
+          metanorma:
+            source:
+              files:
+              - file1
+              - file2
+            collection:
+              organization: org
+              name: name
+            extensions:
+            - html
+            - rxl
+        EOYAML
+      end
+
+      it_behaves_like "a valid manifest"
+
+      its(:extensions) { is_expected.to eq %w[html rxl] }
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/metanorma/metanorma-cli/issues/418

## Summary

Adds output-format selection to `metanorma site generate`, so a run can be
restricted to specific formats instead of building every format the flavor
supports (the expensive PDF path being the motivation).

Two surfaces, both optional:

- CLI: `metanorma site generate --extensions html,rxl` (alias `-x`)
- Manifest: a top-level `extensions:` list in `metanorma.yml`

CLI overrides the manifest; either overrides a collection file's own `format:`,
so the filter applies uniformly across plain documents and collections. With
neither set, behaviour is unchanged (all formats).

Detailed design notes and the propagation trace are on the issue.

## Test plan

- `bundle exec rspec spec/metanorma/site_manifest_spec.rb spec/metanorma/cli/site_generator_spec.rb spec/acceptance/generate_site_spec.rb` — 91 examples, 0 failures
- RuboCop clean on the touched lib files (no new offences)
- Docs updated on the metanorma.org `20260528` batch branch (`_pages/install/site.adoc`)

🤖
