### PR TITLE
export-config: include .xsl and .yaml files in the export tree

### DIFF
--- a/lib/metanorma/cli/flavor.rb
+++ b/lib/metanorma/cli/flavor.rb
@@ -153,6 +153,7 @@ module Metanorma
       EXPORT_CONFIG_FLAVOR_FILES = [
         "metanorma/*/*.adoc",
         "isodoc/*/html/*",
+        "isodoc/*/*.xsl",
         "isodoc/*/*.yml",
         "relaton/render/*.yml",
       ].freeze

--- a/lib/metanorma/cli/flavor.rb
+++ b/lib/metanorma/cli/flavor.rb
@@ -155,7 +155,9 @@ module Metanorma
         "isodoc/*/html/*",
         "isodoc/*/*.xsl",
         "isodoc/*/*.yml",
+        "isodoc/*/*.yaml",
         "relaton/render/*.yml",
+        "relaton/render/*.yaml",
       ].freeze
 
       def export_config_flavor(type)

--- a/spec/acceptance/export_config_spec.rb
+++ b/spec/acceptance/export_config_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe "Metanorma" do
         expect(File.exist?(File.join(export_dir,
                                      "isodoc/iso/iso.international-standard.xsl"))).to be true
         expect(File.exist?(File.join(export_dir,
+                                     "isodoc/iso/i18n-en.yaml"))).to be true
+        expect(File.exist?(File.join(export_dir,
                                      "relaton/render/config.yml"))).to be true
         FileUtils.rm_rf(export_dir) if Dir.exist?(export_dir)
       end

--- a/spec/acceptance/export_config_spec.rb
+++ b/spec/acceptance/export_config_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe "Metanorma" do
                                      "isodoc/iso/html/header.html"))).to be true
         expect(File.exist?(File.join(export_dir,
                                      "isodoc/iso/html/isodoc.scss"))).to be true
+        # https://github.com/metanorma/metanorma-cli/issues/421
+        expect(File.exist?(File.join(export_dir,
+                                     "isodoc/iso/iso.international-standard.xsl"))).to be true
         expect(File.exist?(File.join(export_dir,
                                      "relaton/render/config.yml"))).to be true
         FileUtils.rm_rf(export_dir) if Dir.exist?(export_dir)


### PR DESCRIPTION
Closes https://github.com/metanorma/metanorma-cli/issues/421

`EXPORT_CONFIG_FLAVOR_FILES` had two related coverage gaps:

1. **No `.xsl` glob** — flavour XSLT stylesheets (e.g. `metanorma-iso/lib/isodoc/iso/iso.international-standard.xsl`, `metanorma-ribose/lib/isodoc/ribose/ribose.standard.xsl`) never landed in the export tree. Original use case in metanorma-pdfa#34 was an author wanting to fork the PDF styling and needing the XSLT as starting point.

2. **`.yml` glob misses `.yaml` files** — the i18n config files actually used in flavour gems use the `.yaml` extension (`metanorma-iso/lib/isodoc/iso/i18n-en.yaml`, etc.), so the `isodoc/*/*.yml` and `relaton/render/*.yml` globs silently missed them. Authors forking a flavour for localisation work need those files exported.

Three glob patterns added (`*.xsl`, `*.yaml` under both `isodoc/*/` and `relaton/render/`). Regression spec extended to assert both `isodoc/iso/iso.international-standard.xsl` and `isodoc/iso/i18n-en.yaml` land in the export-config-iso tree.
