### PR TITLE
Drop --field version from docker / packed-mn dispatches in ruby-artifacts.yml

### DIFF
--- a/.github/workflows/ruby-artifacts.yml
+++ b/.github/workflows/ruby-artifacts.yml
@@ -123,22 +123,26 @@ jobs:
           echo "Triggering downstream workflows for version ${{ steps.version.outputs.tag }}"
 
           # Trigger metanorma-docker build
+          # NOTE: --field version was dropped because the receiving
+          # workflow_dispatch declares no inputs; GitHub returns HTTP 422
+          # "Unexpected inputs provided: [version]" and the whole step
+          # exits 1. Docker's build-push reads the metanorma-cli version
+          # from VERSION.mak / Gemfile at build time, so it doesn't need
+          # the input. See metanorma/metanorma-cli#426.
           gh workflow run build-push.yml \
             --repo metanorma/metanorma-docker \
-            --ref main \
-            --field version="${{ steps.version.outputs.tag }}"
+            --ref main
 
           # Trigger metanorma-docker Windows build
           gh workflow run build-push-windows.yml \
             --repo metanorma/metanorma-docker \
-            --ref main \
-            --field version="${{ steps.version.outputs.tag }}"
+            --ref main
 
           # Trigger packed-mn build
+          # NOTE: same input-schema mismatch as the docker dispatches above.
           gh workflow run build.yml \
             --repo metanorma/packed-mn \
-            --ref main \
-            --field version="${{ steps.version.outputs.tag }}"
+            --ref main
 
           echo "Downstream workflows triggered successfully"
         env:

--- a/.github/workflows/ruby-artifacts.yml
+++ b/.github/workflows/ruby-artifacts.yml
@@ -138,11 +138,18 @@ jobs:
             --repo metanorma/metanorma-docker \
             --ref main
 
-          # Trigger packed-mn build
-          # NOTE: same input-schema mismatch as the docker dispatches above.
-          gh workflow run build.yml \
-            --repo metanorma/packed-mn \
-            --ref main
+          # packed-mn dispatch removed: the target workflow file
+          # `build.yml` was renamed/split into per-platform workflows
+          # in metanorma/packed-mn `a4938049` (2020-07-30, "Split
+          # workflows per platform"), so this dispatch has been a 404
+          # for ~6 years. Even fixing the filename wouldn't help: 4 of
+          # the 5 per-platform workflows (alpine, ubuntu, windows,
+          # macos) are currently disabled on packed-mn, and the proper
+          # dispatch path appears to be repository_dispatch with
+          # event-type `metanorma/metanorma-cli` (the same shape
+          # metanorma-docker's release-tag.yml listens for). Wiring
+          # that up is tracked separately; see the metanorma-cli /
+          # packed-mn dispatch-chain follow-up issue.
 
           echo "Downstream workflows triggered successfully"
         env:


### PR DESCRIPTION
Closes https://github.com/metanorma/metanorma-cli/issues/426
Refs https://github.com/metanorma/metanorma-cli/issues/428

## Summary

Every metanorma-cli release since at least 2026-05-16 (≥5 releases) has **silently failed to rebuild metanorma-docker**. The release itself succeeded (gem on rubygems, GH release artifacts uploaded), so the failure was invisible in the release UI; the docker images on Docker Hub have been stale by ~5 versions as a result.

While triaging that, a second dead dispatch surfaced: the `packed-mn build.yml` line in the same step has been a 404 for ~6 years (since `metanorma/packed-mn` split its build into per-platform workflows in 2020). It never executed; nobody noticed because the docker dispatch above it was failing first and short-circuiting the bash step.

## Fix

### docker dispatch (closes #426)

Drop the `--field version="..."` parameter from the docker `build-push.yml` and `build-push-windows.yml` dispatches. The receiving `workflow_dispatch:` declares no `inputs:`, so GitHub rejects the field with `HTTP 422: Unexpected inputs provided: ["version"]`. metanorma-docker reads metanorma-cli version from `VERSION.mak` / `Gemfile` at build time, so the input wasn't load-bearing — it was passing a value the receiver couldn't accept.

### packed-mn dispatch (refs #428)

Remove the `gh workflow run build.yml --repo metanorma/packed-mn` lines entirely. `packed-mn/build.yml` does not exist (file was renamed/split into per-platform workflows in [`metanorma/packed-mn@a4938049`](https://github.com/metanorma/packed-mn/commit/a4938049) on 2020-07-30). The dispatch has been silently 404ing for the full intervening 6 years. Fixing the filename would not have helped either: 4 of the 5 per-platform workflows on packed-mn are currently disabled, and the intended dispatch path (`repository_dispatch` with event-type `metanorma/metanorma-cli` to `release_tag.yml`) has its own independent failure history since 2026-05-17. That deeper chain reconciliation is tracked in **#428**, gated on @ronaldtse confirming whether packed-mn is being deprecated.

Inline `NOTE:` comments at both call sites explain the prior failure modes and point at #426 / #428 so the next maintainer doesn't re-add the dispatches without first reconstructing the receiver-side schema (docker) or chain (packed-mn).

## Verification

1. Merge.
2. Trigger a metanorma-cli release (`gh workflow run release.yml --repo metanorma/metanorma-cli` with `next_version: skip` is the lightest-touch verification).
3. Expected:
   - `ruby-artifacts.yml` completes successfully (no HTTP 422).
   - `metanorma/metanorma-docker/actions` shows a fresh `build-push.yml` + `build-push-windows.yml` run.
   - No packed-mn dispatch is attempted; no noise in the log from a 404 we already know about.

## Follow-ups (out of scope, surfaced for tracking)

- **Observability gap** (release reports green when downstream cascade fails): structural fix tracked in [metanorma/ci#302](https://github.com/metanorma/ci/issues/302) — *"green means published" invariant + downstream-cascade visibility (gated-direct architecture)*.
- **packed-mn chain reconstruction**: tracked in #428 — needs @ronaldtse input on deprecation status before further work.

🤖
