### PR TITLE
ruby-artifacts: also fire downstream-trigger on workflow_dispatch

### DIFF
--- a/.github/workflows/ruby-artifacts.yml
+++ b/.github/workflows/ruby-artifacts.yml
@@ -118,7 +118,11 @@ jobs:
           echo "✅ Workflow validation completed successfully"
 
       - name: Trigger downstream workflows
-        if: github.event_name == 'release'
+        # Fires on a real release event AND on manual workflow_dispatch.
+        # workflow_dispatch lets us verify the downstream chain without
+        # producing a new gem release, and gives a permanent escape hatch
+        # for refreshing docker images when they go stale.
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         run: |
           echo "Triggering downstream workflows for version ${{ steps.version.outputs.tag }}"
 


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-cli/issues/429
Refs https://github.com/metanorma/metanorma-cli/issues/426

## Summary

Widens the `Trigger downstream workflows` step's `if:` gate in `ruby-artifacts.yml` so it fires on `release` events (the original path) **and** on `workflow_dispatch` (new). One-line code change plus an explanatory comment.

```diff
       - name: Trigger downstream workflows
-        if: github.event_name == 'release'
+        # Fires on a real release event AND on manual workflow_dispatch.
+        # workflow_dispatch lets us verify the downstream chain without
+        # producing a new gem release, and gives a permanent escape hatch
+        # for refreshing docker images when they go stale.
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
```

## Why

Two reasons (see #429 for the verification plan that motivated this):

1. **Non-shipping verification of `#427`.** `#427` (merged) fixed the silent-failure chain (`HTTP 422` from `--field version`, plus the 6-year-dead `packed-mn build.yml` dispatch). To prove the fix works end-to-end without producing a new gem release, this widened gate lets us fire `gh workflow run ruby-artifacts.yml --field version=v1.16.5` and exercise the full downstream-dispatch step against the now-fixed code. Acceptance criteria for that verification live in #429.
2. **Permanent escape hatch.** Docker images go stale for reasons unrelated to metanorma-cli releases (system updates, transient registry issues, ops requests). Without this, manual docker-rebuild paths are either (a) bumping `VERSION.mak` in metanorma-docker by hand, (b) firing `gh workflow run build-push.yml --repo metanorma/metanorma-docker` directly — which bypasses the metanorma-cli context — or (c) cutting a real cli release. With the widened gate, `gh workflow run ruby-artifacts.yml --field version=...` becomes the canonical manual-rebuild trigger that also exercises the full chain.

The `workflow_dispatch` trigger already declares `version` as a required input (lines 7-14 of the file), so the input is available to the `Trigger downstream workflows` step's `${{ steps.version.outputs.tag }}` consumer — no other change needed.

## Verification

Will be exercised immediately after merge per the plan in #429. Acceptance criteria: ruby-artifacts.yml workflow_dispatch run completes; `metanorma-docker/build-push.yml` + `build-push-windows.yml` runs appear within ~1 minute.

🤖
