### PR TITLE
Dispatch metanorma-docker release-tag.yml (not build-push.yml) after tests (closes ci#366)

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -19,21 +19,25 @@ jobs:
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
 
   # Docker rebuild gated on tests-passed. Fires only after the rake test
-  # suite has gone green on a tag push. Fixes metanorma/ci#365: docker was
-  # previously triggered off `release: published` in ruby-artifacts.yml
-  # with no test-status check, shipping untested images to docker users
-  # (the least-technical audience in the metanorma distribution — those
-  # who run the image because they cannot recompile the cli stack).
+  # suite has gone green on a tag push. Fixes metanorma/ci#365 (test
+  # gating for the docker chain) + metanorma/ci#366 (reconciliation onto
+  # release-tag.yml so docker's tag actually corresponds to the released
+  # cli version).
   #
-  # Dispatches match the ones ruby-artifacts.yml formerly fired on
-  # release:published — `gh workflow run build-push.yml` + windows variant
-  # on metanorma-docker main. The ruby-artifacts.yml docker step is now
-  # gated to workflow_dispatch only (the deliberate manual escape hatch).
+  # Dispatches metanorma-docker's release-tag.yml via
+  # `repository_dispatch: [metanorma/metanorma-cli]` — the listener that
+  # workflow already exposes but that nothing else dispatches to.
+  # release-tag.yml parses the cli version from client_payload.ref,
+  # updates VERSION.mak + Gemfile, creates the matching `vX.Y.Z` tag on
+  # metanorma-docker, and the tag push then triggers build-push +
+  # build-push-windows AT the tag with the correct version.
   #
-  # Longer-term reconciliation onto metanorma-docker's unused
-  # release-tag.yml `repository_dispatch: [metanorma/metanorma-cli]`
-  # listener is a follow-up; this fix stays cli-side only, no
-  # docker-side changes required.
+  # Replaces the previous shape (metanorma-cli#438) which dispatched
+  # build-push.yml + build-push-windows.yml directly on metanorma-docker
+  # main. That built the LAST tagged version, not the newly-released cli
+  # version, and required manual `gh workflow run release-tag.yml` every
+  # fortnight to create the matching docker tag. This dispatch does that
+  # automatically per release.
   docker-dispatch:
     needs: rake
     if: |
@@ -43,18 +47,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Dispatch docker builds (tests-passed gate)
+      - name: Dispatch metanorma-docker release-tag (tests-passed gate)
         env:
           GH_TOKEN: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
         run: |
-          echo "Rake passed on ${{ github.ref_name }}; dispatching docker builds"
+          echo "Rake passed on ${{ github.ref_name }}; dispatching metanorma-docker release-tag"
 
-          gh workflow run build-push.yml \
-            --repo metanorma/metanorma-docker \
-            --ref main
+          gh api repos/metanorma/metanorma-docker/dispatches \
+            -f event_type=metanorma/metanorma-cli \
+            -f "client_payload[ref]=${{ github.ref }}"
 
-          gh workflow run build-push-windows.yml \
-            --repo metanorma/metanorma-docker \
-            --ref main
-
-          echo "Docker dispatches sent"
+          echo "release-tag.yml dispatch sent for ${{ github.ref_name }}"


### PR DESCRIPTION
Closes https://github.com/metanorma/ci/issues/366

## Summary

Completes the ci#365 fix by closing the tag-creation gap that [metanorma-cli#438](https://github.com/metanorma/metanorma-cli/pull/438) left open. That earlier PR gated the docker dispatch on tests-passed but still dispatched `build-push.yml` on `metanorma-docker` main — which builds off docker's own latest tag, not the newly-released cli version. Every cli release therefore required a manual `gh workflow run release-tag.yml --field next_version=<v>` to create the matching docker tag. This PR closes that loop.

## What changes

Single-file diff to `.github/workflows/rake.yml`, replacing the `docker-dispatch` job's step content (23 insertions, 23 deletions — same line count, different mechanism).

**Before** (`#438` shape, `build-push.yml` on main):

```
gh workflow run build-push.yml --repo metanorma/metanorma-docker --ref main
gh workflow run build-push-windows.yml --repo metanorma/metanorma-docker --ref main
```

**After** (this PR, `release-tag.yml` via `repository_dispatch`):

```
gh api repos/metanorma/metanorma-docker/dispatches \
  -f event_type=metanorma/metanorma-cli \
  -f "client_payload[ref]=${{ github.ref }}"
```

The `event_type=metanorma/metanorma-cli` lands on `metanorma-docker`'s already-exposed `release-tag.yml` listener (which nothing else dispatches to). `release-tag.yml` then parses the cli version from `client_payload.ref`, updates `VERSION.mak` + `Gemfile.lock`, creates the matching `vX.Y.Z` tag on `metanorma-docker`, and the tag push triggers `build-push` + `build-push-windows` AT THE TAG with the correct version.

## Why this matters (the tag-creation gap #438 left)

The [ci#365 scope note](https://github.com/metanorma/metanorma-cli/pull/438) parked the `release-tag.yml` reconciliation as ci#366 "low-priority architectural cleanup." That priority framing was wrong. Without this change:

- Cli tag push → rake tests → tests-passed → dispatch `build-push.yml` on docker main
- `build-push.yml` reads docker's latest tag (e.g. `v1.16.9`), builds an image for that version
- Cli's actual new release (say `v1.16.10`) never gets a matching docker tag; docker's latest stays at `v1.16.9`
- Manual `gh workflow run release-tag.yml --field next_version=1.16.10` required every fortnight

That was unsustainable. This PR closes it.

## After merge

Next cli tag push exercises the full chain automatically:

1. Rake tests run → pass
2. `docker-dispatch` fires `repository_dispatch: metanorma/metanorma-cli` at docker
3. `release-tag.yml` on docker: parses cli version, updates VERSION.mak + Gemfile, tags `vX.Y.Z`, pushes
4. Tag push triggers `build-push` + `build-push-windows` AT the tag → images published under correct version

Zero manual intervention. Combined with metanorma-cli#438's tests-gating, the cli→docker chain is now both **safe** (tests-passed required) and **complete** (correct version tagged).

## What this doesn't fix

- **Windows build-push runner daemon issue** — separate class, hits every Windows run on `metanorma-docker` (docker daemon not running on GH runner). Needs its own ticket on `metanorma-docker` (Ronald's file).
- **rubygems `created_at` timeline gap** (ci#367) — still pending investigation.

🤖
