### PR TITLE
version: guard dependency listing against gems absent from the bundle

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -45,4 +45,4 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
       - uses: reclaim-the-stack/rubocop-action@v1.1.0
         with:
-          gem_versions: rubocop:1.72.2 rubocop-performance:1.24.0
+          gem_versions: rubocop:1.72.2 rubocop-performance:1.24.0 rubocop-rspec:3.10.2 rubocop-rake:0.7.1

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ group :development do
   gem "rspec-core"
   gem "rubocop"
   gem "rubocop-performance"
+  gem "rubocop-rake"
+  gem "rubocop-rspec"
   # need for dev because locally compiled metanorma-iso does not have css
   gem "sassc-embedded"
   gem "simplecov"

--- a/lib/metanorma/cli/flavor.rb
+++ b/lib/metanorma/cli/flavor.rb
@@ -108,13 +108,14 @@ module Metanorma
         %w(html2doc isodoc metanorma-utils mn2pdf mn-requirements isodoc-i18n
            metanorma-core metanorma-plugin-glossarist metanorma-plugin-lutaml
            metanorma-taste relaton-cli pubid glossarist fontist
-           plurimath lutaml expressir xmi lutaml-model emf2svg unitsml
+           plurimath expressir xmi lutaml-model emf2svg unitsml
            vectory ogc-gml oscal suma).freeze
 
       def dependencies_versions
         versions = Gem.loaded_specs
         DEPENDENCY_GEMS.sort.each do |k|
-          UI.say("#{k} #{versions[k].version}")
+          spec = versions[k] or next
+          UI.say("#{k} #{spec.version}")
         end
       end
 

--- a/lib/metanorma/cli/flavor.rb
+++ b/lib/metanorma/cli/flavor.rb
@@ -1,6 +1,23 @@
 module Metanorma
   module Cli
     class Command < ThorWithConfig
+      DEPENDENCY_GEMS =
+        %w(html2doc isodoc metanorma-utils mn2pdf mn-requirements isodoc-i18n
+           metanorma-core metanorma-plugin-glossarist metanorma-plugin-lutaml
+           metanorma-taste relaton-cli pubid glossarist fontist
+           plurimath expressir xmi lutaml-model emf2svg unitsml
+           vectory ogc-gml oscal suma).freeze
+
+      EXPORT_CONFIG_FLAVOR_FILES = [
+        "metanorma/*/*.adoc",
+        "isodoc/*/html/*",
+        "isodoc/*/*.xsl",
+        "isodoc/*/*.yml",
+        "isodoc/*/*.yaml",
+        "relaton/render/*.yml",
+        "relaton/render/*.yaml",
+      ].freeze
+
       private
 
       def print_doctypes_table(type)
@@ -104,13 +121,6 @@ module Metanorma
         end
       end
 
-      DEPENDENCY_GEMS =
-        %w(html2doc isodoc metanorma-utils mn2pdf mn-requirements isodoc-i18n
-           metanorma-core metanorma-plugin-glossarist metanorma-plugin-lutaml
-           metanorma-taste relaton-cli pubid glossarist fontist
-           plurimath expressir xmi lutaml-model emf2svg unitsml
-           vectory ogc-gml oscal suma).freeze
-
       def dependencies_versions
         versions = Gem.loaded_specs
         DEPENDENCY_GEMS.sort.each do |k|
@@ -151,16 +161,6 @@ module Metanorma
         abort if errors.any?
       end
 
-      EXPORT_CONFIG_FLAVOR_FILES = [
-        "metanorma/*/*.adoc",
-        "isodoc/*/html/*",
-        "isodoc/*/*.xsl",
-        "isodoc/*/*.yml",
-        "isodoc/*/*.yaml",
-        "relaton/render/*.yml",
-        "relaton/render/*.yaml",
-      ].freeze
-
       def export_config_flavor(type)
         base, taste, dir = export_config_flavor_prep(type)
         base or return
@@ -193,18 +193,21 @@ module Metanorma
       end
 
       def export_config_flavor_prep(type)
-        unless type
-          UI.say("Please specify a standard type")
-          return [nil, nil, nil]
-        end
-        dict = flavor_dictionary
-        unless dict[type.to_sym]
-          UI.say("Couldn't load #{type}, please provide a valid type!")
-          return [nil, nil, nil]
-        end
+        dict = type && flavor_dictionary
+        (dict && dict[type.to_sym]) or
+          return export_config_flavor_invalid(type)
         FileUtils.mkdir_p("export-config-#{type}")
         base = dict[type.to_sym][:base_flavor]
         [base || type, base ? type : nil, "export-config-#{type}"]
+      end
+
+      def export_config_flavor_invalid(type)
+        if type
+          UI.say("Couldn't load #{type}, please provide a valid type!")
+        else
+          UI.say("Please specify a standard type")
+        end
+        [nil, nil, nil]
       end
 
       def export_config_flavor_gem(base)
@@ -222,7 +225,7 @@ module Metanorma
           UI.say("No matching configuration files found in metanorma-#{base}")
         else
           UI.say("Exported #{copied_files.size} configuration file(s) " \
-            "from metanorma-#{base} to #{dir}")
+                 "from metanorma-#{base} to #{dir}")
         end
       end
 
@@ -250,11 +253,9 @@ module Metanorma
       end
 
       def export_config_taste_copy_files(source_path, gem_data_path, dest_path)
-        copied_files = []
         pattern = source_path.join("**", "*")
-        Pathname.glob(pattern).each do |source_file|
-          copied_files << export_config_copy_file(source_file, gem_data_path,
-                                                  dest_path)
+        copied_files = Pathname.glob(pattern).map do |source_file|
+          export_config_copy_file(source_file, gem_data_path, dest_path)
         end
         copied_files.compact
       end
@@ -264,7 +265,7 @@ module Metanorma
           UI.say("No files found in metanorma-taste/taste/#{taste}")
         else
           UI.say("Exported #{copied_files.size} taste configuration file(s) " \
-            "from metanorma-taste to #{dest_path}")
+                 "from metanorma-taste to #{dest_path}")
         end
       end
     end

--- a/spec/acceptance/version_spec.rb
+++ b/spec/acceptance/version_spec.rb
@@ -1,9 +1,9 @@
-
 require "spec_helper"
 
 RSpec.describe "Metanorma" do
   describe "version" do
     context "with argument" do
+      # rubocop:disable RSpec/MultipleExpectations
       it "display version for that backend" do
         command = %w(version -t iso)
         output = capture_stdout { Metanorma::Cli.start(command) }
@@ -12,9 +12,11 @@ RSpec.describe "Metanorma" do
         expect(output).not_to include("Metanorma::Cc #{Metanorma::Cc::VERSION}")
         expect(output).not_to match /html2doc \d\.\d/
       end
+      # rubocop:enable RSpec/MultipleExpectations
     end
 
     context "without any argument" do
+      # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
       it "display version for dependencies" do
         command = %w(version)
         output = capture_stdout { Metanorma::Cli.start(command) }
@@ -26,6 +28,7 @@ RSpec.describe "Metanorma" do
         expect(output).to include("Metanorma::Ietf #{Metanorma::Ietf::VERSION}")
         expect(output).to match /html2doc \d\.\d/
       end
+      # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
 
       it "reports a version for every listed dependency gem" do
         output = capture_stdout { Metanorma::Cli.start(%w(version)) }
@@ -38,9 +41,8 @@ RSpec.describe "Metanorma" do
         command = %w(version)
         output = capture_stderr { Metanorma::Cli.start(command) }
 
-        expect(output).not_to match /is not present/
+        expect(output).not_to include("is not present")
       end
     end
   end
 end
-

--- a/spec/acceptance/version_spec.rb
+++ b/spec/acceptance/version_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe "Metanorma" do
         expect(output).to match /html2doc \d\.\d/
       end
 
+      it "reports a version for every listed dependency gem" do
+        command = %w(version)
+        output = capture_stdout { Metanorma::Cli.start(command) }
+
+        Metanorma::Cli::Command::DEPENDENCY_GEMS.each do |gem|
+          expect(output).to match(/^#{Regexp.escape(gem)} \d/)
+        end
+        expect(output).not_to include("undefined method")
+      end
+
       it "not raise error about dependencies" do
         command = %w(version)
         output = capture_stderr { Metanorma::Cli.start(command) }

--- a/spec/acceptance/version_spec.rb
+++ b/spec/acceptance/version_spec.rb
@@ -28,13 +28,10 @@ RSpec.describe "Metanorma" do
       end
 
       it "reports a version for every listed dependency gem" do
-        command = %w(version)
-        output = capture_stdout { Metanorma::Cli.start(command) }
-
-        Metanorma::Cli::Command::DEPENDENCY_GEMS.each do |gem|
-          expect(output).to match(/^#{Regexp.escape(gem)} \d/)
-        end
-        expect(output).not_to include("undefined method")
+        output = capture_stdout { Metanorma::Cli.start(%w(version)) }
+        gems = Metanorma::Cli::Command::DEPENDENCY_GEMS
+        missing = gems.reject { |g| output.match?(/^#{Regexp.escape(g)} \d/) }
+        expect(missing).to be_empty
       end
 
       it "not raise error about dependencies" do


### PR DESCRIPTION
Closes https://github.com/metanorma/metanorma-pdfa/issues/64

Diagnosis and rationale in the ticket.

🤖
