### PR TITLE
monthly grammar census over the samples fleet

### DIFF
--- a/.github/scripts/grammar_census.rb
+++ b/.github/scripts/grammar_census.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# grammar_census.rb — Semantic-XML grammar-error census over one samples repo.
-# Part of the monthly grammar census (metanorma-iso#513).
+# grammar_census.rb — Semantic-XML grammar-error census over one samples
+# repo. Part of the monthly grammar census (metanorma-iso#513).
 #
 # Usage: grammar_census.rb REPO_PATH FLAVOR OUTPUT.yaml
 #
@@ -16,56 +16,73 @@ require "yaml"
 require "fileutils"
 
 repo, flavor, out_path = ARGV
-abort "usage: grammar_census.rb REPO_PATH FLAVOR OUTPUT.yaml" unless repo && flavor && out_path
+(repo && flavor && out_path) or
+  abort "usage: grammar_census.rb REPO_PATH FLAVOR OUTPUT.yaml"
 repo = File.expand_path(repo)
 repo_name = File.basename(repo)
 
-manifest = YAML.safe_load(File.read(File.join(repo, "metanorma.yml")))
+manifest = YAML.safe_load_file(File.join(repo, "metanorma.yml"))
 files = manifest.dig("metanorma", "source", "files") ||
   abort("no source.files in metanorma.yml")
 docs = files.select { |f| f.end_with?(".adoc") }
 
+UUID_RE =
+  /\b_?\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\b/
+
 def normalize(msg)
   msg.gsub(/^XML Line \d+:?\d*:?\s*/, "")
-     .gsub(/"[^"]*"/) { |q| q.length > 40 ? '"…"' : q }
-     .gsub(/\b_?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/, "«id»")
-     .strip
+    .gsub(/"[^"]*"/) { |q| q.length > 40 ? '"…"' : q }
+    .gsub(UUID_RE, "«id»")
+    .strip
+end
+
+# strip markup repeatedly, so that nested/split tags cannot survive one pass
+def strip_tags(str)
+  str = str.gsub(/<[^>]*>/, "") while str.match?(/<[^>]*>/)
+  str
+end
+
+def row_message(row)
+  cells = row.scan(%r{<t[dh][^>]*>(.*?)</t[dh]>}m).flatten
+  strip_tags(cells[3].to_s).strip
 end
 
 def harvest_err_html(path)
   html = File.read(path, encoding: "UTF-8")
   html.scan(%r{<tr[^>]*>(.*?)</tr>}m).map(&:first)
-      .select { |r| r.include?("STANDOC_7") }
-      .map do |r|
-    cells = r.scan(%r{<t[dh][^>]*>(.*?)</t[dh]>}m).flatten
-                 .map { |c| c.gsub(/<[^>]+>/, "").strip }
-    cells[3].to_s
-  end.reject(&:empty?)
+    .select { |r| r.include?("STANDOC_7") }
+    .map { |r| row_message(r) }.reject(&:empty?)
 end
 
-census = { "repo" => repo_name, "flavor" => flavor, "docs" => {}, "patterns" => Hash.new(0) }
+census = { "repo" => repo_name, "flavor" => flavor, "docs" => {},
+           "patterns" => Hash.new(0) }
 
 docs.each do |rel|
   src = File.join(repo, rel)
   unless File.exist?(src)
-    census["docs"][rel] = { "exit" => nil, "grammar_errors" => 0, "note" => "MISSING" }
+    census["docs"][rel] = { "exit" => nil, "grammar_errors" => 0,
+                            "note" => "MISSING" }
     next
   end
-  outdir = File.join(Dir.pwd, "census-out", repo_name, rel.sub(/\.adoc$/, "").gsub("/", "--"))
+  outdir = File.join(Dir.pwd, "census-out", repo_name,
+                     rel.sub(/\.adoc$/, "").gsub("/", "--"))
   FileUtils.mkdir_p(outdir)
+  log = File.join(outdir, "compile.log")
   ok = system("bundle", "exec", "metanorma", "compile", rel, "-x", "xml",
               "-t", flavor, "--agree-to-terms", "--no-install-fonts",
-              "-o", outdir, chdir: repo,
-              out: File.join(outdir, "compile.log"),
-              err: File.join(outdir, "compile.log"))
-  errs = Dir[File.join(outdir, "*.err.html")].flat_map { |f| harvest_err_html(f) }
+              "-o", outdir, chdir: repo, out: log, err: log)
+  errs = Dir[File.join(outdir, "*.err.html")]
+    .flat_map { |f| harvest_err_html(f) }
   errs.each { |m| census["patterns"][normalize(m)] += 1 }
-  census["docs"][rel] = { "exit" => ok ? 0 : 1, "grammar_errors" => errs.size }
-  warn "[census] #{repo_name}/#{rel}: exit=#{ok ? 0 : 1} grammar_errors=#{errs.size}"
+  census["docs"][rel] = { "exit" => ok ? 0 : 1,
+                          "grammar_errors" => errs.size }
+  warn "[census] #{repo_name}/#{rel}: exit=#{ok ? 0 : 1} " \
+       "grammar_errors=#{errs.size}"
 end
 
 census["patterns"] = census["patterns"].sort_by { |_, v| -v }.to_h
 FileUtils.mkdir_p(File.dirname(out_path))
 File.write(out_path, census.to_yaml)
 warn "[census] #{repo_name}: #{census['docs'].size} docs, " \
-     "#{census['patterns'].values.sum} errors, #{census['patterns'].size} patterns"
+     "#{census['patterns'].values.sum} errors, " \
+     "#{census['patterns'].size} patterns"

--- a/.github/scripts/grammar_census.rb
+++ b/.github/scripts/grammar_census.rb
@@ -1,0 +1,71 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# grammar_census.rb — Semantic-XML grammar-error census over one samples repo.
+# Part of the monthly grammar census (metanorma-iso#513).
+#
+# Usage: grammar_census.rb REPO_PATH FLAVOR OUTPUT.yaml
+#
+# Compiles every .adoc in the repo's metanorma.yml source.files (the full
+# manifest, deliberately not metanorma.test.yml: the census measures the
+# whole fleet) with `metanorma compile FILE -x xml -t FLAVOR`, harvests
+# "Metanorma XML Syntax" (STANDOC_7) rows from each .err.html, normalizes
+# messages into recurring patterns, and writes a per-repo census fragment.
+
+require "yaml"
+require "fileutils"
+
+repo, flavor, out_path = ARGV
+abort "usage: grammar_census.rb REPO_PATH FLAVOR OUTPUT.yaml" unless repo && flavor && out_path
+repo = File.expand_path(repo)
+repo_name = File.basename(repo)
+
+manifest = YAML.safe_load(File.read(File.join(repo, "metanorma.yml")))
+files = manifest.dig("metanorma", "source", "files") ||
+  abort("no source.files in metanorma.yml")
+docs = files.select { |f| f.end_with?(".adoc") }
+
+def normalize(msg)
+  msg.gsub(/^XML Line \d+:?\d*:?\s*/, "")
+     .gsub(/"[^"]*"/) { |q| q.length > 40 ? '"…"' : q }
+     .gsub(/\b_?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/, "«id»")
+     .strip
+end
+
+def harvest_err_html(path)
+  html = File.read(path, encoding: "UTF-8")
+  html.scan(%r{<tr[^>]*>(.*?)</tr>}m).map(&:first)
+      .select { |r| r.include?("STANDOC_7") }
+      .map do |r|
+    cells = r.scan(%r{<t[dh][^>]*>(.*?)</t[dh]>}m).flatten
+                 .map { |c| c.gsub(/<[^>]+>/, "").strip }
+    cells[3].to_s
+  end.reject(&:empty?)
+end
+
+census = { "repo" => repo_name, "flavor" => flavor, "docs" => {}, "patterns" => Hash.new(0) }
+
+docs.each do |rel|
+  src = File.join(repo, rel)
+  unless File.exist?(src)
+    census["docs"][rel] = { "exit" => nil, "grammar_errors" => 0, "note" => "MISSING" }
+    next
+  end
+  outdir = File.join(Dir.pwd, "census-out", repo_name, rel.sub(/\.adoc$/, "").gsub("/", "--"))
+  FileUtils.mkdir_p(outdir)
+  ok = system("bundle", "exec", "metanorma", "compile", rel, "-x", "xml",
+              "-t", flavor, "--agree-to-terms", "--no-install-fonts",
+              "-o", outdir, chdir: repo,
+              out: File.join(outdir, "compile.log"),
+              err: File.join(outdir, "compile.log"))
+  errs = Dir[File.join(outdir, "*.err.html")].flat_map { |f| harvest_err_html(f) }
+  errs.each { |m| census["patterns"][normalize(m)] += 1 }
+  census["docs"][rel] = { "exit" => ok ? 0 : 1, "grammar_errors" => errs.size }
+  warn "[census] #{repo_name}/#{rel}: exit=#{ok ? 0 : 1} grammar_errors=#{errs.size}"
+end
+
+census["patterns"] = census["patterns"].sort_by { |_, v| -v }.to_h
+FileUtils.mkdir_p(File.dirname(out_path))
+File.write(out_path, census.to_yaml)
+warn "[census] #{repo_name}: #{census['docs'].size} docs, " \
+     "#{census['patterns'].values.sum} errors, #{census['patterns'].size} patterns"

--- a/.github/scripts/grammar_census_report.rb
+++ b/.github/scripts/grammar_census_report.rb
@@ -1,0 +1,63 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# grammar_census_report.rb — merge per-repo census fragments into the
+# monthly grammar-census report (metanorma-iso#513).
+#
+# Usage: grammar_census_report.rb FRAGMENT_DIR REPORT.md
+#
+# Reads every *.yaml fragment written by grammar_census.rb and emits a
+# markdown report: headline tally, per-repo totals, compile failures,
+# and the pattern ranking (top 40).
+
+require "yaml"
+
+frag_dir, report_path = ARGV
+abort "usage: grammar_census_report.rb FRAGMENT_DIR REPORT.md" unless frag_dir && report_path
+
+frags = Dir[File.join(frag_dir, "**", "*.yaml")].sort.map { |f| YAML.safe_load(File.read(f, encoding: "UTF-8")) }
+abort "no census fragments found under #{frag_dir}" if frags.empty?
+
+date = Time.now.strftime("%Y-%m-%d")
+total_docs = frags.sum { |f| f["docs"].size }
+total_errs = frags.sum { |f| f["patterns"].values.sum }
+patterns = Hash.new(0)
+frags.each { |f| f["patterns"].each { |k, v| patterns[k] += v } }
+fails = frags.flat_map do |f|
+  f["docs"].select { |_, d| d["exit"] != 0 }.keys.map { |k| "#{f['repo']}/#{k}" }
+end
+
+lines = []
+lines << "## Grammar census — #{date}"
+lines << ""
+lines << "Released metanorma stack; full `metanorma.yml` manifests. " \
+         "Series context: https://github.com/metanorma/metanorma-iso/issues/513"
+lines << ""
+lines << "**#{total_docs} documents, #{total_errs} grammar errors, " \
+         "#{patterns.size} distinct patterns, #{fails.size} compile failures.**"
+lines << ""
+lines << "| repo | docs | grammar errors | compile failures |"
+lines << "|---|---|---|---|"
+frags.sort_by { |f| -f["patterns"].values.sum }.each do |f|
+  nfail = f["docs"].count { |_, d| d["exit"] != 0 }
+  lines << "| #{f['repo']} | #{f['docs'].size} | #{f['patterns'].values.sum} | #{nfail} |"
+end
+unless fails.empty?
+  lines << ""
+  lines << "### Compile failures"
+  lines << ""
+  fails.each { |f| lines << "- `#{f}`" }
+end
+lines << ""
+lines << "### Patterns by frequency (top 40)"
+lines << ""
+lines << "| hits | pattern |"
+lines << "|---|---|"
+patterns.sort_by { |_, v| -v }.first(40).each do |k, v|
+  lines << "| #{v} | #{k.gsub('|', '\\|')} |"
+end
+lines << ""
+lines << "🤖"
+
+File.write(report_path, lines.join("\n") + "\n")
+warn "[census] report: #{total_docs} docs, #{total_errs} errors, #{patterns.size} patterns"

--- a/.github/scripts/grammar_census_report.rb
+++ b/.github/scripts/grammar_census_report.rb
@@ -13,10 +13,17 @@
 require "yaml"
 
 frag_dir, report_path = ARGV
-abort "usage: grammar_census_report.rb FRAGMENT_DIR REPORT.md" unless frag_dir && report_path
+(frag_dir && report_path) or
+  abort "usage: grammar_census_report.rb FRAGMENT_DIR REPORT.md"
 
-frags = Dir[File.join(frag_dir, "**", "*.yaml")].sort.map { |f| YAML.safe_load(File.read(f, encoding: "UTF-8")) }
-abort "no census fragments found under #{frag_dir}" if frags.empty?
+frags = Dir[File.join(frag_dir, "**", "*.yaml")]
+  .map { |f| YAML.safe_load(File.read(f, encoding: "UTF-8")) }
+frags.empty? and abort "no census fragments found under #{frag_dir}"
+
+# markdown table cell: escape backslashes before pipes
+def cell(str)
+  str.gsub("\\") { "\\\\" }.gsub("|") { "\\|" }
+end
 
 date = Time.now.strftime("%Y-%m-%d")
 total_docs = frags.sum { |f| f["docs"].size }
@@ -24,23 +31,27 @@ total_errs = frags.sum { |f| f["patterns"].values.sum }
 patterns = Hash.new(0)
 frags.each { |f| f["patterns"].each { |k, v| patterns[k] += v } }
 fails = frags.flat_map do |f|
-  f["docs"].select { |_, d| d["exit"] != 0 }.keys.map { |k| "#{f['repo']}/#{k}" }
+  f["docs"].reject { |_, d| d["exit"].zero? }.keys
+    .map { |k| "#{f['repo']}/#{k}" }
 end
 
 lines = []
 lines << "## Grammar census — #{date}"
 lines << ""
 lines << "Released metanorma stack; full `metanorma.yml` manifests. " \
-         "Series context: https://github.com/metanorma/metanorma-iso/issues/513"
+         "Series context: " \
+         "https://github.com/metanorma/metanorma-iso/issues/513"
 lines << ""
 lines << "**#{total_docs} documents, #{total_errs} grammar errors, " \
-         "#{patterns.size} distinct patterns, #{fails.size} compile failures.**"
+         "#{patterns.size} distinct patterns, " \
+         "#{fails.size} compile failures.**"
 lines << ""
 lines << "| repo | docs | grammar errors | compile failures |"
 lines << "|---|---|---|---|"
 frags.sort_by { |f| -f["patterns"].values.sum }.each do |f|
   nfail = f["docs"].count { |_, d| d["exit"] != 0 }
-  lines << "| #{f['repo']} | #{f['docs'].size} | #{f['patterns'].values.sum} | #{nfail} |"
+  lines << "| #{f['repo']} | #{f['docs'].size} | " \
+           "#{f['patterns'].values.sum} | #{nfail} |"
 end
 unless fails.empty?
   lines << ""
@@ -54,10 +65,11 @@ lines << ""
 lines << "| hits | pattern |"
 lines << "|---|---|"
 patterns.sort_by { |_, v| -v }.first(40).each do |k, v|
-  lines << "| #{v} | #{k.gsub('|', '\\|')} |"
+  lines << "| #{v} | #{cell(k)} |"
 end
 lines << ""
 lines << "🤖"
 
-File.write(report_path, lines.join("\n") + "\n")
-warn "[census] report: #{total_docs} docs, #{total_errs} errors, #{patterns.size} patterns"
+File.write(report_path, "#{lines.join("\n")}\n")
+warn "[census] report: #{total_docs} docs, #{total_errs} errors, " \
+     "#{patterns.size} patterns"

--- a/.github/workflows/grammar-census.yml
+++ b/.github/workflows/grammar-census.yml
@@ -9,6 +9,9 @@ on:
     - cron: "0 2 1 * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   census:
     strategy:
@@ -84,6 +87,9 @@ jobs:
     needs: census
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/grammar-census.yml
+++ b/.github/workflows/grammar-census.yml
@@ -1,0 +1,109 @@
+# Monthly grammar census over the samples fleet (metanorma-iso#513).
+# Compiles every document in every samples repo's full metanorma.yml manifest
+# to Semantic XML on the released metanorma stack, harvests the jing grammar
+# errors, and lodges the dated report as a new issue each month.
+name: grammar-census
+
+on:
+  schedule:
+    - cron: "0 2 1 * *"
+  workflow_dispatch:
+
+jobs:
+  census:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { repo: mn-samples-iso, flavor: iso }
+          - { repo: mn-samples-cc, flavor: cc }
+          - { repo: mn-samples-iec, flavor: iec }
+          - { repo: mn-samples-iec-private, flavor: iec, private: true }
+          - { repo: mn-samples-ogc, flavor: ogc }
+          - { repo: mn-samples-iho, flavor: iho }
+          - { repo: mn-samples-ietf, flavor: ietf }
+          - { repo: mn-samples-bipm, flavor: bipm }
+          # jcgm has no gem of its own: its documents declare
+          # mn-document-class: bipm and compile under the bipm flavor
+          - { repo: mn-samples-jcgm, flavor: bipm }
+          # metanorma-bsi is distributed via GitHub Packages, not rubygems
+          - { repo: mn-samples-bsi, flavor: bsi, ghpkg: true }
+          - { repo: mn-samples-itu, flavor: itu }
+          - { repo: mn-samples-ieee, flavor: ieee }
+          - { repo: mn-samples-ieee-private, flavor: ieee, private: true }
+          - { repo: mn-samples-nist, flavor: nist }
+          - { repo: mn-samples-ribose, flavor: ribose }
+          - { repo: mn-samples-pdfa, flavor: pdfa }
+          - { repo: mn-samples-oiml, flavor: oiml }
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: metanorma/${{ matrix.repo }}
+          path: samples
+          token: ${{ matrix.private && secrets.METANORMA_CI_PAT_TOKEN || github.token }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Install census environment (released stack)
+        env:
+          BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+        run: |
+          mkdir census-env
+          {
+            echo 'source "https://rubygems.org"'
+            echo 'gem "metanorma-cli"'
+            echo 'gem "metanorma-nist"'
+            echo 'gem "benchmark"'
+            echo 'gem "ostruct"'
+            if [ "${{ matrix.ghpkg }}" = "true" ]; then
+              echo 'source "https://rubygems.pkg.github.com/metanorma" do'
+              echo '  gem "metanorma-bsi"'
+              echo 'end'
+            fi
+          } > census-env/Gemfile
+          BUNDLE_GEMFILE="$PWD/census-env/Gemfile" bundle install
+
+      - name: Run census
+        run: >
+          BUNDLE_GEMFILE="$PWD/census-env/Gemfile"
+          ruby .github/scripts/grammar_census.rb
+          samples ${{ matrix.flavor }} fragments/${{ matrix.repo }}.yaml
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: census-${{ matrix.repo }}
+          path: fragments/
+
+  report:
+    needs: census
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: census-*
+          merge-multiple: true
+          path: fragments
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Build report
+        run: ruby .github/scripts/grammar_census_report.rb fragments report.md
+
+      - name: Lodge report issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          gh issue create --repo "${{ github.repository }}"
+          --title "Grammar census $(date +%Y-%m)"
+          --body-file report.md


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-iso/issues/513

Monthly grammar census: a scheduled workflow (1st of each month, `workflow_dispatch` for manual runs) compiles every document in every samples repo's **full** `metanorma.yml` manifest (not the test subsets) to Semantic XML on the **released** metanorma stack, harvests jing grammar errors into a normalized pattern census, and lodges the dated report — headline tally, per-repo totals, compile failures, top-40 patterns — as a **new issue per month** on this repo.

Coverage: all 17 fleet repos, including `iec-private`/`ieee-private` (checkout via the existing `METANORMA_CI_PAT_TOKEN`) and `bsi` (`metanorma-bsi` from GitHub Packages via the same token); `jcgm` compiles under the `bipm` flavor per its `mn-document-class`. Per-repo matrix fan-out with fragment artifacts and an aggregating report job. Scripts smoke-tested locally against the fleet.

Note: monthly issues are created with `GITHUB_TOKEN`, which cannot add them to org project 15 — add manually or wire a project-scoped PAT later if wanted.

🤖
