### PR TITLE
grammar-census: add mn-samples-iso-10303 to samples fleet matrix

### DIFF
--- a/.github/workflows/grammar-census.yml
+++ b/.github/workflows/grammar-census.yml
@@ -19,6 +19,14 @@ jobs:
       matrix:
         include:
           - { repo: mn-samples-iso, flavor: iso }
+          # mn-samples-iso-10303 is collection-shaped (metanorma.yml lists
+          # collection.yml, not .adoc files). The current grammar_census.rb
+          # only compiles .adoc files listed in `source.files`, so this row
+          # produces an empty census fragment today; grammar_census.rb needs
+          # extending to recurse collection.yml → docref/fileref → .adoc for
+          # this row to contribute real coverage. Tracked as follow-up for
+          # the grammar-work sibling.
+          - { repo: mn-samples-iso-10303, flavor: iso }
           - { repo: mn-samples-cc, flavor: cc }
           - { repo: mn-samples-iec, flavor: iec }
           - { repo: mn-samples-iec-private, flavor: iec, private: true }

--- a/.github/workflows/grammar-census.yml
+++ b/.github/workflows/grammar-census.yml
@@ -19,13 +19,7 @@ jobs:
       matrix:
         include:
           - { repo: mn-samples-iso, flavor: iso }
-          # mn-samples-iso-10303 is collection-shaped (metanorma.yml lists
-          # collection.yml, not .adoc files). The current grammar_census.rb
-          # only compiles .adoc files listed in `source.files`, so this row
-          # produces an empty census fragment today; grammar_census.rb needs
-          # extending to recurse collection.yml → docref/fileref → .adoc for
-          # this row to contribute real coverage. Tracked as follow-up for
-          # the grammar-work sibling.
+          # collection-shaped; census recursion pending
           - { repo: mn-samples-iso-10303, flavor: iso }
           - { repo: mn-samples-cc, flavor: cc }
           - { repo: mn-samples-iec, flavor: iec }


### PR DESCRIPTION
Refs https://github.com/metanorma/suma/issues/107

## Why

Phase 4a of the suma#107 → metanorma-cli integration arc. Brings the newly-bootstrapped mn-samples-iso-10303 repo (synthetic dummy ISO 10303 collection fixture) into the monthly grammar-census matrix so its documents fall in scope for the Semantic-XML jing-error census.

## Changes

- `.github/workflows/grammar-census.yml` — add `{ repo: mn-samples-iso-10303, flavor: iso }` matrix row immediately after `mn-samples-iso`.
- Inline comment above the row documents that the current `grammar_census.rb` script filters `source.files` for `.adoc` only, so this collection-shape row produces an empty fragment until the script is extended to recurse `collection.yml → docref/fileref → .adoc`. Flagged as follow-up for the grammar-work sibling.

## Non-scope

- `grammar_census.rb` extension to recurse collection manifests — follow-up.
- Phase 3 cimas-config integration and Phase 4b in-tree fixture / test case — separate PRs.

🤖
