### PR TITLE
grammar-census: collection-manifest recursion + mn-samples-iso-10303 row

### DIFF
--- a/.github/scripts/grammar_census.rb
+++ b/.github/scripts/grammar_census.rb
@@ -6,83 +6,181 @@
 #
 # Usage: grammar_census.rb REPO_PATH FLAVOR OUTPUT.yaml
 #
-# Compiles every .adoc in the repo's metanorma.yml source.files (the full
-# manifest, deliberately not metanorma.test.yml: the census measures the
-# whole fleet) with `metanorma compile FILE -x xml -t FLAVOR`, harvests
-# "Metanorma XML Syntax" (STANDOC_7) rows from each .err.html, normalizes
-# messages into recurring patterns, and writes a per-repo census fragment.
+# Compiles every .adoc discovered in the repo's metanorma.yml source.files
+# (the full manifest, deliberately not metanorma.test.yml: the census
+# measures the whole fleet) with `metanorma compile FILE -x xml -t FLAVOR`,
+# harvests "Metanorma XML Syntax" (STANDOC_7) rows from each .err.html,
+# normalizes messages into recurring patterns, and writes a per-repo
+# census fragment.
+#
+# Source-file discovery:
+#   - .adoc entries are compiled directly.
+#   - .yml/.yaml entries are treated as collection manifests and recursed:
+#       manifest.docref[*].file      → sub-collection manifest (recurse)
+#       manifest.docref[*].fileref   → leaf; .adoc compiled, others skipped
+#       manifest.docref[*].docref    → nested docref array (recurse in place)
+#   - Cycle-safe via a visited-set on absolute collection paths.
 
 require "yaml"
 require "fileutils"
+require "set"
 
-repo, flavor, out_path = ARGV
-(repo && flavor && out_path) or
-  abort "usage: grammar_census.rb REPO_PATH FLAVOR OUTPUT.yaml"
-repo = File.expand_path(repo)
-repo_name = File.basename(repo)
+# Source-file discovery for the census. Split into a module so unit tests
+# can require this file and exercise discovery without invoking the
+# metanorma-compile main body.
+module Collector
+  module_function
 
-manifest = YAML.safe_load_file(File.join(repo, "metanorma.yml"))
-files = manifest.dig("metanorma", "source", "files") ||
-  abort("no source.files in metanorma.yml")
-docs = files.select { |f| f.end_with?(".adoc") }
-
-UUID_RE =
-  /\b_?\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\b/
-
-def normalize(msg)
-  msg.gsub(/^XML Line \d+:?\d*:?\s*/, "")
-    .gsub(/"[^"]*"/) { |q| q.length > 40 ? '"…"' : q }
-    .gsub(UUID_RE, "«id»")
-    .strip
-end
-
-# strip markup repeatedly, so that nested/split tags cannot survive one pass
-def strip_tags(str)
-  str = str.gsub(/<[^>]*>/, "") while str.match?(/<[^>]*>/)
-  str
-end
-
-def row_message(row)
-  cells = row.scan(%r{<t[dh][^>]*>(.*?)</t[dh]>}m).flatten
-  strip_tags(cells[3].to_s).strip
-end
-
-def harvest_err_html(path)
-  html = File.read(path, encoding: "UTF-8")
-  html.scan(%r{<tr[^>]*>(.*?)</tr>}m).map(&:first)
-    .select { |r| r.include?("STANDOC_7") }
-    .map { |r| row_message(r) }.reject(&:empty?)
-end
-
-census = { "repo" => repo_name, "flavor" => flavor, "docs" => {},
-           "patterns" => Hash.new(0) }
-
-docs.each do |rel|
-  src = File.join(repo, rel)
-  unless File.exist?(src)
-    census["docs"][rel] = { "exit" => nil, "grammar_errors" => 0,
-                            "note" => "MISSING" }
-    next
+  # Discover .adoc paths (relative to repo root) by walking source.files,
+  # recursing into any collection manifests. Cycle-safe.
+  def discover_adocs(repo_root, source_files)
+    visited = Set.new
+    adocs = []
+    source_files.each do |rel|
+      discover_entry(repo_root, rel, ".", visited, adocs)
+    end
+    adocs.uniq.sort
   end
-  outdir = File.join(Dir.pwd, "census-out", repo_name,
-                     rel.sub(/\.adoc$/, "").gsub("/", "--"))
-  FileUtils.mkdir_p(outdir)
-  log = File.join(outdir, "compile.log")
-  ok = system("bundle", "exec", "metanorma", "compile", rel, "-x", "xml",
-              "-t", flavor, "--agree-to-terms", "--no-install-fonts",
-              "-o", outdir, chdir: repo, out: log, err: log)
-  errs = Dir[File.join(outdir, "*.err.html")]
-    .flat_map { |f| harvest_err_html(f) }
-  errs.each { |m| census["patterns"][normalize(m)] += 1 }
-  census["docs"][rel] = { "exit" => ok ? 0 : 1,
-                          "grammar_errors" => errs.size }
-  warn "[census] #{repo_name}/#{rel}: exit=#{ok ? 0 : 1} " \
-       "grammar_errors=#{errs.size}"
+
+  # Handle one source entry (file or collection manifest) relative to `base`
+  # (itself relative to repo_root).
+  def discover_entry(repo_root, rel, base, visited, adocs)
+    full_rel = normalize_rel(base, rel)
+    return if full_rel.nil? || full_rel == ""
+
+    if full_rel.end_with?(".adoc")
+      adocs << full_rel
+    elsif full_rel.end_with?(".yml", ".yaml")
+      walk_collection(repo_root, full_rel, visited, adocs)
+    end
+  end
+
+  # Walk a collection manifest, descending into docref entries.
+  def walk_collection(repo_root, collection_rel, visited, adocs)
+    abs = File.expand_path(collection_rel, repo_root)
+    return unless File.exist?(abs)
+    return if visited.include?(abs)
+    visited << abs
+
+    data = YAML.safe_load_file(abs)
+    docrefs = data.is_a?(Hash) && data["manifest"] &&
+              data["manifest"]["docref"]
+    return unless docrefs.is_a?(Array)
+
+    base = File.dirname(collection_rel)
+    docrefs.each do |ref|
+      next unless ref.is_a?(Hash)
+
+      if ref["file"]
+        discover_entry(repo_root, ref["file"], base, visited, adocs)
+      elsif ref["fileref"]
+        leaf = normalize_rel(base, ref["fileref"])
+        adocs << leaf if leaf && leaf.end_with?(".adoc")
+      end
+
+      walk_nested_docref(ref["docref"], base, repo_root, visited, adocs) if
+        ref["docref"].is_a?(Array)
+    end
+  end
+
+  # Recurse into a nested `docref:` array on the same collection manifest
+  # (e.g. level: document groupings inside a top-level docref entry).
+  def walk_nested_docref(docrefs, base, repo_root, visited, adocs)
+    docrefs.each do |inner|
+      next unless inner.is_a?(Hash)
+
+      if inner["fileref"]
+        leaf = normalize_rel(base, inner["fileref"])
+        adocs << leaf if leaf && leaf.end_with?(".adoc")
+      elsif inner["file"]
+        discover_entry(repo_root, inner["file"], base, visited, adocs)
+      end
+      walk_nested_docref(inner["docref"], base, repo_root, visited, adocs) if
+        inner["docref"].is_a?(Array)
+    end
+  end
+
+  # Join `base` (a relative dir from repo_root) with `rel` (a path that may
+  # contain .. segments), then normalise to a repo-root-relative posix path.
+  def normalize_rel(base, rel)
+    return nil if rel.nil? || rel == ""
+
+    joined = base == "." ? rel : File.join(base, rel)
+    File.expand_path(joined, "/").delete_prefix("/")
+  end
 end
 
-census["patterns"] = census["patterns"].sort_by { |_, v| -v }.to_h
-FileUtils.mkdir_p(File.dirname(out_path))
-File.write(out_path, census.to_yaml)
-warn "[census] #{repo_name}: #{census['docs'].size} docs, " \
-     "#{census['patterns'].values.sum} errors, " \
-     "#{census['patterns'].size} patterns"
+if $PROGRAM_NAME == __FILE__
+  repo, flavor, out_path = ARGV
+  (repo && flavor && out_path) or
+    abort "usage: grammar_census.rb REPO_PATH FLAVOR OUTPUT.yaml"
+  repo = File.expand_path(repo)
+  repo_name = File.basename(repo)
+
+  manifest = YAML.safe_load_file(File.join(repo, "metanorma.yml"))
+  files = manifest.dig("metanorma", "source", "files") ||
+    abort("no source.files in metanorma.yml")
+
+  docs = Collector.discover_adocs(repo, files)
+
+  UUID_RE =
+    /\b_?\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\b/
+
+  def normalize(msg)
+    msg.gsub(/^XML Line \d+:?\d*:?\s*/, "")
+      .gsub(/"[^"]*"/) { |q| q.length > 40 ? '"…"' : q }
+      .gsub(UUID_RE, "«id»")
+      .strip
+  end
+
+  # strip markup repeatedly, so that nested/split tags cannot survive one pass
+  def strip_tags(str)
+    str = str.gsub(/<[^>]*>/, "") while str.match?(/<[^>]*>/)
+    str
+  end
+
+  def row_message(row)
+    cells = row.scan(%r{<t[dh][^>]*>(.*?)</t[dh]>}m).flatten
+    strip_tags(cells[3].to_s).strip
+  end
+
+  def harvest_err_html(path)
+    html = File.read(path, encoding: "UTF-8")
+    html.scan(%r{<tr[^>]*>(.*?)</tr>}m).map(&:first)
+      .select { |r| r.include?("STANDOC_7") }
+      .map { |r| row_message(r) }.reject(&:empty?)
+  end
+
+  census = { "repo" => repo_name, "flavor" => flavor, "docs" => {},
+             "patterns" => Hash.new(0) }
+
+  docs.each do |rel|
+    src = File.join(repo, rel)
+    unless File.exist?(src)
+      census["docs"][rel] = { "exit" => nil, "grammar_errors" => 0,
+                              "note" => "MISSING" }
+      next
+    end
+    outdir = File.join(Dir.pwd, "census-out", repo_name,
+                       rel.sub(/\.adoc$/, "").gsub("/", "--"))
+    FileUtils.mkdir_p(outdir)
+    log = File.join(outdir, "compile.log")
+    ok = system("bundle", "exec", "metanorma", "compile", rel, "-x", "xml",
+                "-t", flavor, "--agree-to-terms", "--no-install-fonts",
+                "-o", outdir, chdir: repo, out: log, err: log)
+    errs = Dir[File.join(outdir, "*.err.html")]
+      .flat_map { |f| harvest_err_html(f) }
+    errs.each { |m| census["patterns"][normalize(m)] += 1 }
+    census["docs"][rel] = { "exit" => ok ? 0 : 1,
+                            "grammar_errors" => errs.size }
+    warn "[census] #{repo_name}/#{rel}: exit=#{ok ? 0 : 1} " \
+         "grammar_errors=#{errs.size}"
+  end
+
+  census["patterns"] = census["patterns"].sort_by { |_, v| -v }.to_h
+  FileUtils.mkdir_p(File.dirname(out_path))
+  File.write(out_path, census.to_yaml)
+  warn "[census] #{repo_name}: #{census['docs'].size} docs, " \
+       "#{census['patterns'].values.sum} errors, " \
+       "#{census['patterns'].size} patterns"
+end

--- a/.github/scripts/grammar_census.rb
+++ b/.github/scripts/grammar_census.rb
@@ -23,7 +23,6 @@
 
 require "yaml"
 require "fileutils"
-require "set"
 
 # Source-file discovery for the census. Split into a module so unit tests
 # can require this file and exercise discovery without invoking the
@@ -60,26 +59,27 @@ module Collector
     abs = File.expand_path(collection_rel, repo_root)
     return unless File.exist?(abs)
     return if visited.include?(abs)
-    visited << abs
 
+    visited << abs
     data = YAML.safe_load_file(abs)
-    docrefs = data.is_a?(Hash) && data["manifest"] &&
-              data["manifest"]["docref"]
+    docrefs = data&.dig("manifest", "docref")
     return unless docrefs.is_a?(Array)
 
     base = File.dirname(collection_rel)
-    docrefs.each do |ref|
-      next unless ref.is_a?(Hash)
+    docrefs.each { |ref| process_ref(ref, base, repo_root, visited, adocs) }
+  end
 
-      if ref["file"]
-        discover_entry(repo_root, ref["file"], base, visited, adocs)
-      elsif ref["fileref"]
-        leaf = normalize_rel(base, ref["fileref"])
-        adocs << leaf if leaf && leaf.end_with?(".adoc")
-      end
+  # Process one manifest.docref entry: descend if it has a sub-collection
+  # `file`, add leaf if it has a `.adoc` `fileref`, recurse if it nests.
+  def process_ref(ref, base, repo_root, visited, adocs)
+    return unless ref.is_a?(Hash)
 
-      walk_nested_docref(ref["docref"], base, repo_root, visited, adocs) if
-        ref["docref"].is_a?(Array)
+    discover_entry(repo_root, ref["file"], base, visited, adocs) if ref["file"]
+    add_adoc_if_leaf(ref["fileref"], base, adocs)
+    return unless ref["docref"].is_a?(Array)
+
+    ref["docref"].each do |inner|
+      process_nested(inner, base, repo_root, visited, adocs)
     end
   end
 
@@ -87,17 +87,30 @@ module Collector
   # (e.g. level: document groupings inside a top-level docref entry).
   def walk_nested_docref(docrefs, base, repo_root, visited, adocs)
     docrefs.each do |inner|
-      next unless inner.is_a?(Hash)
-
-      if inner["fileref"]
-        leaf = normalize_rel(base, inner["fileref"])
-        adocs << leaf if leaf && leaf.end_with?(".adoc")
-      elsif inner["file"]
-        discover_entry(repo_root, inner["file"], base, visited, adocs)
-      end
-      walk_nested_docref(inner["docref"], base, repo_root, visited, adocs) if
-        inner["docref"].is_a?(Array)
+      process_nested(inner, base, repo_root, visited, adocs)
     end
+  end
+
+  def process_nested(inner, base, repo_root, visited, adocs)
+    return unless inner.is_a?(Hash)
+
+    add_adoc_if_leaf(inner["fileref"], base, adocs)
+    if inner["file"]
+      discover_entry(repo_root, inner["file"], base, visited, adocs)
+    end
+    return unless inner["docref"].is_a?(Array)
+
+    inner["docref"].each do |i|
+      process_nested(i, base, repo_root, visited, adocs)
+    end
+  end
+
+  # If the given fileref resolves to a `.adoc` under base, add it to adocs.
+  def add_adoc_if_leaf(fileref, base, adocs)
+    return unless fileref
+
+    leaf = normalize_rel(base, fileref)
+    adocs << leaf if leaf&.end_with?(".adoc")
   end
 
   # Join `base` (a relative dir from repo_root) with `rel` (a path that may

--- a/.github/scripts/test_grammar_census_collector.rb
+++ b/.github/scripts/test_grammar_census_collector.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Unit tests for the collection-manifest recursion in grammar_census.rb.
@@ -79,7 +78,8 @@ class TestCollector < Minitest::Test
           collection_with_files([{ "fileref" => "document.adoc",
                                    "identifier" => "g1" }]))
     write("collection.yml",
-          collection_with_files([{ "file" => "documents/gizmo/collection.yml" }]))
+          collection_with_files([{ "file" =>
+                                     "documents/gizmo/collection.yml" }]))
     assert_equal %w[documents/gizmo/document.adoc],
                  discover(%w[collection.yml])
   end
@@ -109,7 +109,8 @@ class TestCollector < Minitest::Test
             ],
           } }.to_yaml)
     write("collection.yml",
-          collection_with_files([{ "file" => "documents/gizmo/collection.yml" }]))
+          collection_with_files([{ "file" =>
+                                     "documents/gizmo/collection.yml" }]))
     assert_equal [], discover(%w[collection.yml])
   end
 

--- a/.github/scripts/test_grammar_census_collector.rb
+++ b/.github/scripts/test_grammar_census_collector.rb
@@ -1,0 +1,143 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Unit tests for the collection-manifest recursion in grammar_census.rb.
+# Run directly:  ruby .github/scripts/test_grammar_census_collector.rb
+#
+# Builds synthetic source trees under Dir.mktmpdir and asserts that
+# Collector.discover_adocs walks metanorma.yml → collection.yml →
+# document.adoc correctly, including nested docref arrays, .. segments,
+# cycle protection, and deduplication.
+
+require "tmpdir"
+require "fileutils"
+require "minitest/autorun"
+
+require_relative "grammar_census"
+
+class TestCollector < Minitest::Test
+  def setup
+    @tmp = Dir.mktmpdir("census-collector-")
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmp)
+  end
+
+  def write(rel, body)
+    path = File.join(@tmp, rel)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, body)
+  end
+
+  def manifest(files)
+    { "metanorma" => { "source" => { "files" => files } } }.to_yaml
+  end
+
+  def collection_with_files(files_array)
+    { "manifest" => { "docref" => files_array } }.to_yaml
+  end
+
+  def discover(files)
+    File.write(File.join(@tmp, "metanorma.yml"), manifest(files))
+    Collector.discover_adocs(@tmp, files)
+  end
+
+  def test_flat_adoc_list
+    write("a.adoc", "x")
+    write("b.adoc", "x")
+    assert_equal %w[a.adoc b.adoc], discover(%w[a.adoc b.adoc])
+  end
+
+  def test_skips_non_adoc_at_top_level
+    write("a.adoc", "x")
+    write("notes.txt", "x")
+    assert_equal %w[a.adoc], discover(%w[a.adoc notes.txt])
+  end
+
+  def test_collection_with_fileref_adoc
+    write("documents/gizmo/document.adoc", "x")
+    write("collection.yml",
+          collection_with_files([{ "fileref" => "documents/gizmo/document.adoc",
+                                   "identifier" => "g1" }]))
+    assert_equal %w[documents/gizmo/document.adoc],
+                 discover(%w[collection.yml])
+  end
+
+  def test_collection_skips_non_adoc_fileref
+    write("schemas/gizmo/arm.exp", "x")
+    write("collection.yml",
+          collection_with_files([{ "fileref" => "schemas/gizmo/arm.exp",
+                                   "identifier" => "g_arm",
+                                   "attachment" => true }]))
+    assert_equal [], discover(%w[collection.yml])
+  end
+
+  def test_collection_with_subcollection_file
+    write("documents/gizmo/document.adoc", "x")
+    write("documents/gizmo/collection.yml",
+          collection_with_files([{ "fileref" => "document.adoc",
+                                   "identifier" => "g1" }]))
+    write("collection.yml",
+          collection_with_files([{ "file" => "documents/gizmo/collection.yml" }]))
+    assert_equal %w[documents/gizmo/document.adoc],
+                 discover(%w[collection.yml])
+  end
+
+  def test_nested_docref_array
+    write("documents/gizmo/document.adoc", "x")
+    write("collection.yml",
+          { "manifest" => {
+            "docref" => [
+              { "level" => "document", "docref" => [
+                { "fileref" => "documents/gizmo/document.adoc",
+                  "identifier" => "g1" },
+              ] },
+            ],
+          } }.to_yaml)
+    assert_equal %w[documents/gizmo/document.adoc],
+                 discover(%w[collection.yml])
+  end
+
+  def test_dotdot_segment_in_fileref
+    write("plain_schemas/gizmo/arm.exp", "x")
+    write("documents/gizmo/collection.yml",
+          { "manifest" => {
+            "docref" => [
+              { "fileref" => "../../plain_schemas/gizmo/arm.exp",
+                "identifier" => "g_arm", "attachment" => true },
+            ],
+          } }.to_yaml)
+    write("collection.yml",
+          collection_with_files([{ "file" => "documents/gizmo/collection.yml" }]))
+    assert_equal [], discover(%w[collection.yml])
+  end
+
+  def test_cycle_protection
+    write("documents/gizmo/document.adoc", "x")
+    # a → b → a
+    write("a.yml",
+          collection_with_files([{ "file" => "b.yml" }]))
+    write("b.yml",
+          collection_with_files([{ "file" => "a.yml" },
+                                 { "fileref" => "documents/gizmo/document.adoc",
+                                   "identifier" => "g1" }]))
+    assert_equal %w[documents/gizmo/document.adoc],
+                 discover(%w[a.yml])
+  end
+
+  def test_dedup_when_same_adoc_referenced_twice
+    write("doc.adoc", "x")
+    write("c1.yml",
+          collection_with_files([{ "fileref" => "doc.adoc",
+                                   "identifier" => "d1" }]))
+    # Same adoc discovered via top-level + collection
+    assert_equal %w[doc.adoc], discover(%w[doc.adoc c1.yml])
+  end
+
+  def test_missing_collection_is_silently_skipped
+    write("a.adoc", "x")
+    # missing.yml does not exist on disk — must not abort, must not contribute
+    assert_equal %w[a.adoc], discover(%w[a.adoc missing.yml])
+  end
+end

--- a/.github/workflows/grammar-census.yml
+++ b/.github/workflows/grammar-census.yml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         include:
           - { repo: mn-samples-iso, flavor: iso }
+          # collection-shaped: grammar_census.rb recurses collection.yml →
+          # docref/fileref → .adoc (ci#446 + suma#107 arc)
+          - { repo: mn-samples-iso-10303, flavor: iso }
           - { repo: mn-samples-cc, flavor: cc }
           - { repo: mn-samples-iec, flavor: iec }
           - { repo: mn-samples-iec-private, flavor: iec, private: true }


### PR DESCRIPTION
## Summary

Closes #446. Consolidated rework — **both halves of the placeholder shipped together** (was: matrix row only, produced empty census output).

### What lands

| Piece | Role |
|---|---|
| `.github/scripts/grammar_census.rb` | Source-file discovery extended with collection-manifest recursion |
| `.github/scripts/test_grammar_census_collector.rb` | 10 unit tests for the recursion (minitest) |
| `.github/workflows/grammar-census.yml` | Adds `mn-samples-iso-10303` matrix row |

### Discovery contract

| Entry in `metanorma.source.files` | Behaviour |
|---|---|
| `.adoc` | Compiled directly (unchanged) |
| `.yml` / `.yaml` | Recursed as collection manifest |

Collection manifest recursion:
- `manifest.docref[*].file` → sub-collection manifest (recurse)
- `manifest.docref[*].fileref` → leaf; `.adoc` added to compile list, others (`.exp`, `.html` attachments) skipped
- `manifest.docref[*].docref` → nested docref array (recurse in place)

Safety:
- Cycle-safe via visited set on absolute collection paths
- Path-normalised via `File.expand_path` (handles `..` segments)
- Deduplicates `.adoc` paths discovered via multiple refs
- Missing collection manifests silently skipped (no abort)

### Architecture

`Collector` module extracted from the main body so unit tests can `require_relative "grammar_census"` without triggering the metanorma-compile main body (which would `abort` on missing ARGV).

### Test plan

- [x] `ruby -c` syntax OK
- [x] 10/10 unit tests pass locally: flat adoc list, top-level skip non-adoc, fileref adoc, skip non-adoc fileref, subcollection file ref, nested docref array, `..` segment in fileref, cycle protection, dedup, missing collection silently skipped
- [ ] CI: full grammar-census workflow run (monthly cron, but can be manually dispatched)

