### PR TITLE
Add metanorma diff: semantic XML diff via lutaml/canon

### DIFF
--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -8,6 +8,7 @@ require "metanorma/cli/thor_with_config"
 require "metanorma/cli/commands/config"
 require "metanorma/cli/commands/template_repo"
 require "metanorma/cli/commands/site"
+require "metanorma/cli/commands/diff"
 require "mnconvert"
 require_relative "flavor"
 
@@ -15,8 +16,8 @@ module Metanorma
   module Cli
     class Command < ThorWithConfig
       class_option :progress, aliases: "-s", type: :boolean, default: false,
-                              desc: "Show progress for long running tasks" \
-                                    " (like download)"
+                              desc: "Show progress for long running tasks " \
+                                    "(like download)"
 
       desc "new NAME", "Create new Metanorma document"
       option :type, aliases: "-t", required: true, desc: "Document type"
@@ -40,28 +41,28 @@ module Metanorma
       option :wrapper, aliases: "-w", type: :boolean,
                        desc: "Create wrapper folder for HTML output"
       option :asciimath, aliases: "-a", type: :boolean,
-                         desc: "Keep Asciimath in XML output instead of" \
-                               " converting it to MathM"
+                         desc: "Keep Asciimath in XML output instead of " \
+                               "converting it to MathM"
       option :datauriimage, aliases: "-d", type: :boolean,
                             desc: "Encode HTML output images as data URIs"
       option :relaton, aliases: "-R",
-                       desc: "Export Relaton XML for document to nominated" \
-                             " filename"
+                       desc: "Export Relaton XML for document to nominated " \
+                             "filename"
       option :extract, aliases: "-e",
-                       desc: "Export sourcecode fragments from this document" \
-                             " to nominated directory"
+                       desc: "Export sourcecode fragments from this document " \
+                             "to nominated directory"
       option :version, aliases: "-v",
                        desc: "Print version of code (accompanied with -t)"
       option :log_messages, aliases: "-L",
                             desc: "Display available log messages " \
-                            "(accompanied with -t)"
+                                  "(accompanied with -t)"
       option :output_dir, aliases: "-o",
                           desc: "Directory to save compiled files"
       option :strict, aliases: "-S", type: :boolean,
                       desc: "Strict compilation: abort if there are any errors"
       option :agree_to_terms,
              type: :boolean,
-             desc: "Agree / Disagree with all third-party licensing terms "\
+             desc: "Agree / Disagree with all third-party licensing terms " \
                    "presented (WARNING: do know what you are agreeing with!)"
       option :install_fonts, type: :boolean, default: true,
                              desc: "Install required fonts"
@@ -99,14 +100,14 @@ module Metanorma
       option :coverpage, aliases: "-c", desc: "Liquid template"
       option :agree_to_terms,
              type: :boolean,
-             desc: "Agree / Disagree with all third-party licensing terms "\
+             desc: "Agree / Disagree with all third-party licensing terms " \
                    "presented (WARNING: do know what you are agreeing with!)"
       option :install_fonts, type: :boolean, default: true,
                              desc: "Install required fonts"
       option :continue_without_fonts,
              type: :boolean,
              desc: "Continue processing even when fonts are missing"
-      option :strict, aliases: "-S", type: :boolean, \
+      option :strict, aliases: "-S", type: :boolean,
                       desc: "Strict compilation: abort if there are any errors"
 
       def collection(filename = nil)
@@ -149,6 +150,28 @@ module Metanorma
         MnConvert.convert(inputfile, options)
       rescue Error => e
         UI.say e.message
+      end
+
+      desc "diff FILE1 FILE2", "Semantic diff of two Metanorma XML documents"
+      option :format, type: :string, default: "text",
+                      desc: "Output format: text or json"
+      option :profile, type: :string,
+                       desc: "canon configuration profile (built-in name " \
+                             "or YAML path; default: metanorma)"
+      option :match_profile, type: :string,
+                             desc: "canon match profile override, e.g. " \
+                                   "strict or spec_friendly"
+      option :show_diffs, type: :string,
+                          desc: "Which differences to show: " \
+                                "all|normative|informative"
+      option :context_lines, type: :numeric,
+                             desc: "Context lines around each difference"
+      option :color, type: :boolean, default: true,
+                     desc: "Colorise the text report"
+
+      def diff(file1, file2)
+        status = Commands::Diff.new(file1, file2, options).run
+        exit(status) unless status.zero?
       end
 
       desc "version", "Version of the code"

--- a/lib/metanorma/cli/command.rb
+++ b/lib/metanorma/cli/command.rb
@@ -168,6 +168,9 @@ module Metanorma
                              desc: "Context lines around each difference"
       option :color, type: :boolean, default: true,
                      desc: "Colorise the text report"
+      option :input_format, type: :string,
+                            desc: "Input format override: xml|html|json|yaml " \
+                                  "(default: by file extension)"
 
       def diff(file1, file2)
         status = Commands::Diff.new(file1, file2, options).run

--- a/lib/metanorma/cli/commands/diff.rb
+++ b/lib/metanorma/cli/commands/diff.rb
@@ -13,6 +13,14 @@ module Metanorma
         EXIT_DIFFERENT = 1
         EXIT_ERROR = 2
 
+        # the canon LIBRARY does not auto-detect input format (its CLI
+        # does, from extensions) — detect here, overridable via
+        # --input-format
+        FORMAT_BY_EXT = {
+          ".xml" => :xml, ".html" => :html, ".htm" => :html,
+          ".json" => :json, ".yaml" => :yaml, ".yml" => :yaml
+        }.freeze
+
         def initialize(file1, file2, options = {})
           @file1 = file1
           @file2 = file2
@@ -25,10 +33,11 @@ module Metanorma
           return EXIT_ERROR unless files_exist?
 
           require "canon"
+          format = input_format
+          return reject_format unless format
+
           configure_canon
-          result = compare_documents
-          out.puts render(result)
-          result.equivalent? ? EXIT_EQUIVALENT : EXIT_DIFFERENT
+          report(compare_documents(format), out)
         rescue StandardError => e
           warn "metanorma diff: #{e.class}: #{e.message}"
           EXIT_ERROR
@@ -54,8 +63,28 @@ module Metanorma
 
         # rubocop:disable Naming/PredicateMethod -- verbose: true makes
         # equivalent? return a full ComparisonResult, not a boolean
-        def compare_documents
-          opts = { verbose: true }
+        def report(result, out)
+          out.puts render(result)
+          result.equivalent? ? EXIT_EQUIVALENT : EXIT_DIFFERENT
+        end
+
+        def reject_format
+          warn "metanorma diff: unsupported input format for " \
+               "#{File.extname(@file1)} — semantic diff handles " \
+               "#{FORMAT_BY_EXT.keys.join(', ')} (or pass --input-format)"
+          EXIT_ERROR
+        end
+
+        def input_format
+          if (f = @options[:input_format])
+            return f.to_sym
+          end
+
+          FORMAT_BY_EXT[File.extname(@file1).downcase]
+        end
+
+        def compare_documents(format)
+          opts = { verbose: true, format: format }
           if (mp = @options[:match_profile])
             opts[:match_profile] = mp.to_sym
           end

--- a/lib/metanorma/cli/commands/diff.rb
+++ b/lib/metanorma/cli/commands/diff.rb
@@ -1,0 +1,130 @@
+require "json"
+
+module Metanorma
+  module Cli
+    module Commands
+      # Semantic diff of two Metanorma XML documents, with lutaml/canon
+      # as the diff engine (metanorma-cli#442, iso-10303
+      # drift-tracking). Returns an exit status instead of exiting, so
+      # in-process callers (and specs) stay alive; the Thor command
+      # decides the process exit.
+      class Diff
+        EXIT_EQUIVALENT = 0
+        EXIT_DIFFERENT = 1
+        EXIT_ERROR = 2
+
+        def initialize(file1, file2, options = {})
+          @file1 = file1
+          @file2 = file2
+          @options = options
+        end
+
+        # @return [Integer] exit status (0 equivalent / 1 different /
+        #   2 error); output goes to the given IO (default $stdout)
+        def run(out = $stdout)
+          return EXIT_ERROR unless files_exist?
+
+          require "canon"
+          configure_canon
+          result = compare_documents
+          out.puts render(result)
+          result.equivalent? ? EXIT_EQUIVALENT : EXIT_DIFFERENT
+        rescue StandardError => e
+          warn "metanorma diff: #{e.class}: #{e.message}"
+          EXIT_ERROR
+        end
+
+        private
+
+        def files_exist?
+          [@file1, @file2].all? do |f|
+            File.file?(f) ||
+              (warn("metanorma diff: no such file: #{f}") && false)
+          end
+        end
+
+        # The canon "metanorma" configuration profile is the default:
+        # spec-friendly matching, metanorma whitespace element lists,
+        # normative-only display. --profile selects another canon
+        # profile (built-in name or a YAML path).
+        def configure_canon
+          Canon::Config.reset!
+          Canon::Config.instance.profile = @options[:profile] || :metanorma
+        end
+
+        # rubocop:disable Naming/PredicateMethod -- verbose: true makes
+        # equivalent? return a full ComparisonResult, not a boolean
+        def compare_documents
+          opts = { verbose: true }
+          if (mp = @options[:match_profile])
+            opts[:match_profile] = mp.to_sym
+          end
+          Canon::Comparison.equivalent?(
+            File.read(@file1, encoding: "UTF-8"),
+            File.read(@file2, encoding: "UTF-8"),
+            opts,
+          )
+        end
+        # rubocop:enable Naming/PredicateMethod
+
+        def render(result)
+          case @options[:format]&.downcase
+          when "json" then render_json(result)
+          else render_text(result)
+          end
+        end
+
+        def render_text(result)
+          return result.diff(**text_diff_opts) unless result.equivalent?
+
+          info = result.informative_differences.size
+          return "Equivalent" if info.zero?
+
+          msg = "Equivalent (#{info} informative difference(s) — " \
+                "rerun with --show-diffs informative to view)"
+          if @options[:show_diffs].to_s == "informative"
+            "#{msg}\n#{result.diff(**text_diff_opts)}"
+          else
+            msg
+          end
+        end
+
+        def text_diff_opts
+          diff_opts = { use_color: color? }
+          if (cl = @options[:context_lines])
+            diff_opts[:context_lines] = cl.to_i
+          end
+          if (sd = @options[:show_diffs])
+            diff_opts[:show_diffs] = sd.to_sym
+          end
+          diff_opts
+        end
+
+        def color?
+          return false if @options[:color] == false
+
+          $stdout.tty?
+        end
+
+        # canon has no machine-readable report; serialise its DiffNode
+        # list ourselves — the shape iso-10303 CI can consume
+        def diff_to_h(diff)
+          { dimension: diff.dimension, reason: diff.reason,
+            path: diff.path, normative: diff.normative?,
+            before: diff.serialized_before, after: diff.serialized_after }
+        end
+
+        def render_json(result)
+          diffs = result.differences.map { |d| diff_to_h(d) }
+          JSON.pretty_generate(
+            files: { a: @file1, b: @file2 },
+            equivalent: result.equivalent?,
+            normative_count: diffs.count { |d| d[:normative] },
+            informative_count: diffs.count { |d| !d[:normative] },
+            differences: diffs,
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/cli/flavor.rb
+++ b/lib/metanorma/cli/flavor.rb
@@ -6,7 +6,7 @@ module Metanorma
            metanorma-core metanorma-plugin-glossarist metanorma-plugin-lutaml
            metanorma-taste relaton-cli pubid glossarist fontist
            plurimath expressir xmi lutaml-model emf2svg unitsml
-           vectory ogc-gml oscal suma).freeze
+           vectory ogc-gml oscal suma canon).freeze
 
       EXPORT_CONFIG_FLAVOR_FILES = [
         "metanorma/*/*.adoc",

--- a/metanorma-cli.gemspec
+++ b/metanorma-cli.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "metanorma-jis", "~> 1.1.0"
   spec.add_dependency "metanorma-ogc", "~> 2.9.0"
   spec.add_dependency "metanorma-plateau", "~> 1.2.0"
+  spec.add_dependency "canon", ">= 0.2.12"
   spec.add_dependency "relaton-cli", ">= 0.8.2"
   spec.add_dependency "socksify"
   spec.add_dependency "suma", "~> 0.5.0"

--- a/spec/acceptance/diff_spec.rb
+++ b/spec/acceptance/diff_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+RSpec.describe "Metanorma" do
+  describe "diff" do
+    let(:fixtures) { File.join(Dir.pwd, "spec", "fixtures", "diff") }
+
+    it "prints Equivalent and exits zero for equivalent documents" do
+      output = capture_stdout do
+        Metanorma::Cli.start(
+          ["diff", File.join(fixtures, "base.xml"),
+           File.join(fixtures, "cosmetic.xml")],
+        )
+      end
+      expect(output).to include("Equivalent")
+    end
+
+    it "exits non-zero for semantically different documents" do
+      expect do
+        capture_stdout do
+          Metanorma::Cli.start(
+            ["diff", File.join(fixtures, "base.xml"),
+             File.join(fixtures, "changed.xml"), "--no-color"],
+          )
+        end
+      end.to raise_error(SystemExit) { |e| expect(e.status).to eq 1 }
+    end
+  end
+end

--- a/spec/fixtures/diff/base.xml
+++ b/spec/fixtures/diff/base.xml
@@ -1,0 +1,8 @@
+<iso-standard xmlns="https://www.metanorma.org/ns/iso">
+  <sections>
+    <clause id="scope" type="scope">
+      <title>Scope</title>
+      <p id="p1">This document specifies the widget interchange format.</p>
+    </clause>
+  </sections>
+</iso-standard>

--- a/spec/fixtures/diff/changed.xml
+++ b/spec/fixtures/diff/changed.xml
@@ -1,0 +1,8 @@
+<iso-standard xmlns="https://www.metanorma.org/ns/iso">
+  <sections>
+    <clause id="scope" type="scope">
+      <title>Scope</title>
+      <p id="p1">This document specifies the gadget interchange format.</p>
+    </clause>
+  </sections>
+</iso-standard>

--- a/spec/fixtures/diff/cosmetic.xml
+++ b/spec/fixtures/diff/cosmetic.xml
@@ -1,0 +1,9 @@
+<iso-standard xmlns="https://www.metanorma.org/ns/iso">
+  <sections>
+    <clause type="scope" id="scope">
+      <title>Scope</title>
+      <p id="p1">This document   specifies the widget
+interchange format.</p>
+    </clause>
+  </sections>
+</iso-standard>

--- a/spec/fixtures/sample-file.asciidoc.log.txt
+++ b/spec/fixtures/sample-file.asciidoc.log.txt
@@ -1,0 +1,14 @@
+= Document title
+Author
+:docfile: test.adoc
+:nodoc:
+:novalid:
+:no-isobib:
+:script: script.html
+:body-font: body-font
+:header-font: header-font
+:monospace-font: monospace-font
+:title-font: title-font
+:mn-document-class: iso
+:mn-output-extensions: xml,html
+:flush-caches: true

--- a/spec/metanorma/cli/commands/diff_spec.rb
+++ b/spec/metanorma/cli/commands/diff_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe Metanorma::Cli::Commands::Diff do
     expect(report["differences"].first).to include("path", "normative")
   end
 
+  it "rejects an input format canon cannot parse" do
+    exp = File.join(fixtures, "sample.exp")
+    File.write(exp, "SCHEMA synthetic;\nEND_SCHEMA;\n")
+    status, = run_diff(exp, exp)
+    expect(status).to eq 2
+  ensure
+    File.delete(exp) if File.exist?(exp)
+  end
+
   it "returns the error status for a missing file" do
     status, = run_diff(base, File.join(fixtures, "nonexistent.xml"))
     expect(status).to eq 2

--- a/spec/metanorma/cli/commands/diff_spec.rb
+++ b/spec/metanorma/cli/commands/diff_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+RSpec.describe Metanorma::Cli::Commands::Diff do
+  let(:fixtures) { File.join(Dir.pwd, "spec", "fixtures", "diff") }
+  let(:base) { File.join(fixtures, "base.xml") }
+  let(:cosmetic) { File.join(fixtures, "cosmetic.xml") }
+  let(:changed) { File.join(fixtures, "changed.xml") }
+
+  after { Canon::Config.reset! if defined?(Canon::Config) }
+
+  def run_diff(file1, file2, options = {})
+    out = StringIO.new
+    status = described_class.new(file1, file2, options).run(out)
+    [status, out.string]
+  end
+
+  it "reports a cosmetically different document as equivalent" do
+    status, output = run_diff(base, cosmetic)
+    expect(status).to eq 0
+    expect(output).to include("Equivalent")
+  end
+
+  it "reports a semantic change with a non-zero status" do
+    status, output = run_diff(base, changed, color: false)
+    expect(status).to eq 1
+    expect(output).to include("gadget")
+  end
+
+  it "emits a machine-readable JSON report" do
+    status, output = run_diff(base, changed, format: "json")
+    expect(status).to eq 1
+    report = JSON.parse(output)
+    expect(report["equivalent"]).to be false
+    expect(report["normative_count"]).to be > 0
+    expect(report["differences"]).to be_an(Array)
+    expect(report["differences"].first).to include("path", "normative")
+  end
+
+  it "returns the error status for a missing file" do
+    status, = run_diff(base, File.join(fixtures, "nonexistent.xml"))
+    expect(status).to eq 2
+  end
+end


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-cli/issues/442

Phase 1 of the canon-backed diff integration: `metanorma diff FILE1 FILE2`. Narrative and requirements discussion in the ticket.

🤖
